### PR TITLE
refactor: deprecates solidity node

### DIFF
--- a/docs/Tron-overview.md
+++ b/docs/Tron-overview.md
@@ -1,47 +1,47 @@
 
 # 1. Project Repository
 
-Github Url: [https://github.com/tronprotocol](https://github.com/tronprotocol)    
-[java-tron](https://github.com/tronprotocol/java-tron) is the source code of the MainNet.  
-[protocol](https://github.com/tronprotocol/protocol) is the defination of the api and data structure.  
-[wallet-cli](https://github.com/tronprotocol/wallet-cli) is the official command line wallet.   
+Github Url: [https://github.com/tronprotocol](https://github.com/tronprotocol)
+[java-tron](https://github.com/tronprotocol/java-tron) is the source code of the MainNet.
+[protocol](https://github.com/tronprotocol/protocol) is the definition of the api and data structure.
+[wallet-cli](https://github.com/tronprotocol/wallet-cli) is the official command line wallet.
 
-MainNet Configuration:  
-[https://github.com/tronprotocol/TronDeployment/blob/master/main_net_config.conf](https://github.com/tronprotocol/TronDeployment/blob/master/main_net_config.conf)    
-TestNet Configuration:   
-[https://github.com/tronprotocol/TronDeployment/blob/master/test_net_config.conf](https://github.com/tronprotocol/TronDeployment/blob/master/test_net_config.conf)    
+MainNet Configuration:
+[https://github.com/tronprotocol/TronDeployment/blob/master/main_net_config.conf](https://github.com/tronprotocol/TronDeployment/blob/master/main_net_config.conf)
+TestNet Configuration:
+[https://github.com/tronprotocol/TronDeployment/blob/master/test_net_config.conf](https://github.com/tronprotocol/TronDeployment/blob/master/test_net_config.conf)
 
 # 2. SRs and Committee
 
 <h2> 2.1 How to Become a Super Representative </h2>
 
- In TRON network, any account can apply to become a super representative candidate. Every account can vote for super representative candidates. The top 27 candidates with the most votes are the super representatives. Super representatives can produce blocks. The votes will be counted every 6 hours, so super representatives may also change every 6 hours.  
+ In TRON network, any account can apply to become a super representative candidate. Every account can vote for super representative candidates. The top 27 candidates with the most votes are the super representatives. Super representatives can produce blocks. The votes will be counted every 6 hours, so super representatives may also change every 6 hours.
 
  To prevent vicious attack, TRON network burns 9999 TRX from the account that applies to become a super representative candidate.
 
 <h2> 2.2 Super Representatives Election </h2>
 
- To vote, you need to have TRON Power(TP). To get TRON Power, you need to freeze TRX. Every 1 frozen TRX accounts for one TRON Power(TP). Every account in TRON network has the right to vote for a super representative candidate. After you unfreeze your frozen TRX, you will lose the responding TRON Power(TP), so your previous vote will be invalid.  
+ To vote, you need to have TRON Power(TP). To get TRON Power, you need to freeze TRX. Every 1 frozen TRX accounts for one TRON Power(TP). Every account in TRON network has the right to vote for a super representative candidate. After you unfreeze your frozen TRX, you will lose the responding TRON Power(TP), so your previous vote will be invalid.
 
- Note: Only your latest vote will be counted in TRON network which means your previous vote will be over written by your latest vote.  
+ Note: Only your latest vote will be counted in TRON network which means your previous vote will be over written by your latest vote.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 
 ```text
-freezebalance 10,000,000 3 // Freeze 10 TRX to get 10 TRON Power(TP)  
-votewitness witness1 4 witness2 6 // Vote 4 votes for witness1, 6 votes for witness2  
-votewitness witness1 3 witness2 7 // Vote 3 votes for witness1, 7 votes for witness2  
+freezebalance 10,000,000 3 // Freeze 10 TRX to get 10 TRON Power(TP)
+votewitness witness1 4 witness2 6 // Vote 4 votes for witness1, 6 votes for witness2
+votewitness witness1 3 witness2 7 // Vote 3 votes for witness1, 7 votes for witness2
 ```
 
 The final output above is: Vote 3 votes for witness1, 7 votes for witness2
 
 <h2> 2.3 Reward for Super Representatives </h2>
 
-**Votes Reward:**  
-Every 6 hours, the top 127 super representative candidates with the most votes will share a total amount of 115,200 TRX according to their votes percentage. The annual votes reward is 168,192,000 TRX in total. 
+**Votes Reward:**
+Every 6 hours, the top 127 super representative candidates with the most votes will share a total amount of 115,200 TRX according to their votes percentage. The annual votes reward is 168,192,000 TRX in total.
 
-**Block Producing Reward:**   
-Every time after a super representative produces a block, it will be reward 32 TRX. The 27 super representatives take turns to produce blocks every 3 seconds. The annual block producing reward is 336,384,000 TRX in total.  
+**Block Producing Reward:**
+Every time after a super representative produces a block, it will be reward 32 TRX. The 27 super representatives take turns to produce blocks every 3 seconds. The annual block producing reward is 336,384,000 TRX in total.
 
 Every time after a super representative produces a block, the 32 TRX block producing reward will be sent to it's sub-account. The sub-account is a read-only account, it allows a withdraw action from sub-account to super representative account every 24 hours.
 
@@ -49,58 +49,58 @@ Every time after a super representative produces a block, the 32 TRX block produ
 
 <h3> 2.4.1 What is Committee </h3>
 
-Committee can modify the TRON network parameters, like transacton fees, block producing reward amount, etc. Committee is composed of the current 27 super representatives. Every super representative has the right to start a proposal. The proposal will be passed after it gets more than 19 approves from the super representatives and will become valid in the next maintenance period.
+Committee can modify the TRON network parameters, like transaction fees, block producing reward amount, etc. Committee is composed of the current 27 super representatives. Every super representative has the right to start a proposal. The proposal will be passed after it gets more than 19 approves from the super representatives and will become valid in the next maintenance period.
 
 <h3> 2.4.2 Create a Proposal </h3>
 
-Only the account of a super representative can create a proposal.   
-The network parameters can be modified([min,max]):  
+Only the account of a super representative can create a proposal.
+The network parameters can be modified([min,max]):
 
-- 0: MAINTENANCE_TIME_INTERVAL, [3 * 27* 1000, 24 * 3600 * 1000] //super representative votes count time interval, currently 6 * 3600 * 1000 ms  
-- 1: ACCOUNT_UPGRADE_COST, [0, 100 000 000 000 000 000]  //the fee to apply to become a super representative candidate, currently 9999_000_000 SUN   
-- 2: CREATE_ACCOUNT_FEE, [0, 100 000 000 000  000 000] //the fee to create an account, currently 100_000 SUN  
-- 3: TRANSACTION_FEE, [0, 100 000 000 000 000 000] //the fee for bandwidth, currently 10 SUN/byte  
-- 4: ASSET_ISSUE_FEE, [0, 100 000 000 000 000 000] //the fee to issue an asset, currently 1024_000_000 SUN  
-- 5: WITNESS_PAY_PER_BLOCK, [0, 100 000 000 000 000 000] //the block producing reward, currently 32_000_000 SUN  
-- 6: WITNESS_STANDBY_ALLOWANCE, [0, 100 000 000 000 000 000] //the votes reward for top 127 super representative candidates, currently 115_200_000_000 SUN   
-- 7: CREATE_NEW_ACCOUNT_FEE_IN_SYSTEM_CONTRACT, //the fee to create an account in system, currently 0 SUN  
-- 8: CREATE_NEW_ACCOUNT_BANDWIDTH_RATE, //the consumption of bandwith or TRX while creating an account, using together with #7  
-- 9: ALLOW_CREATION_OF_CONTRACTS, //to enable the VM  
-- 10: REMOVE_THE_POWER_OF_THE_GR, //to clear the votes of GR  
-- 11: ENERGY_FEE, [0,100 000 000 000 000 000] //SUN  
-- 12: EXCHANGE_CREATE_FEE, [0, 100 000 000 000 000 000] //SUN  
-- 13: MAX_CPU_TIME_OF_ONE_TX, [0, 1000] //ms  
-- 14: ALLOW_UPDATE_ACCOUNT_NAME, //to allow users to change account name and allow account duplicate name, currently 0, means false  
-- 15: ALLOW_SAME_TOKEN_NAME, //to allow create a token with duplicate name, currently 1, means true  
-- 16: ALLOW_DELEGATE_RESOURCE, //to enable the resource delegation  
-- 17: TOTAL_ENERGY_LIMIT, //to modify the energy limit  
-- 18: ALLOW_TVM_TRANSFER_TRC10, //to allow smart contract to transfer TRC-10 token, currently 0, means false  
+- 0: MAINTENANCE_TIME_INTERVAL, [3 * 27* 1000, 24 * 3600 * 1000] //super representative votes count time interval, currently 6 * 3600 * 1000 ms
+- 1: ACCOUNT_UPGRADE_COST, [0, 100 000 000 000 000 000]  //the fee to apply to become a super representative candidate, currently 9999_000_000 SUN
+- 2: CREATE_ACCOUNT_FEE, [0, 100 000 000 000  000 000] //the fee to create an account, currently 100_000 SUN
+- 3: TRANSACTION_FEE, [0, 100 000 000 000 000 000] //the fee for bandwidth, currently 10 SUN/byte
+- 4: ASSET_ISSUE_FEE, [0, 100 000 000 000 000 000] //the fee to issue an asset, currently 1024_000_000 SUN
+- 5: WITNESS_PAY_PER_BLOCK, [0, 100 000 000 000 000 000] //the block producing reward, currently 32_000_000 SUN
+- 6: WITNESS_STANDBY_ALLOWANCE, [0, 100 000 000 000 000 000] //the votes reward for top 127 super representative candidates, currently 115_200_000_000 SUN
+- 7: CREATE_NEW_ACCOUNT_FEE_IN_SYSTEM_CONTRACT, //the fee to create an account in system, currently 0 SUN
+- 8: CREATE_NEW_ACCOUNT_BANDWIDTH_RATE, //the consumption of bandwidth or TRX while creating an account, using together with #7
+- 9: ALLOW_CREATION_OF_CONTRACTS, //to enable the VM
+- 10: REMOVE_THE_POWER_OF_THE_GR, //to clear the votes of GR
+- 11: ENERGY_FEE, [0,100 000 000 000 000 000] //SUN
+- 12: EXCHANGE_CREATE_FEE, [0, 100 000 000 000 000 000] //SUN
+- 13: MAX_CPU_TIME_OF_ONE_TX, [0, 1000] //ms
+- 14: ALLOW_UPDATE_ACCOUNT_NAME, //to allow users to change account name and allow account duplicate name, currently 0, means false
+- 15: ALLOW_SAME_TOKEN_NAME, //to allow create a token with duplicate name, currently 1, means true
+- 16: ALLOW_DELEGATE_RESOURCE, //to enable the resource delegation
+- 17: TOTAL_ENERGY_LIMIT, //to modify the energy limit
+- 18: ALLOW_TVM_TRANSFER_TRC10, //to allow smart contract to transfer TRC-10 token, currently 0, means false
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 ```text
-createproposal id value  
-id: the serial number (0 ~ 18)  
-value: the parameter value  
+createproposal id value
+id: the serial number (0 ~ 18)
+value: the parameter value
 ```
 
 Note: In TRON network, 1 TRX = 1000_000 SUN
 
 <h3> 2.4.3 Vote for a Proposal </h3>
 
-Proposal only support YES vote. Since the creation time of the proposal, the proposal is valid within 3 days. If the proposal does not receive enough YES votes within the period of validity, the proposal will be invalid beyond the period of validity. Yes vote can be cancelled.  
+Proposal only support YES vote. Since the creation time of the proposal, the proposal is valid within 3 days. If the proposal does not receive enough YES votes within the period of validity, the proposal will be invalid beyond the period of validity. Yes vote can be cancelled.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 ```text
 approveProposal id is_or_not_add_approval
-id: proposal id  
-is_or_not_add_approval: YES vote or cancel YES vote  
+id: proposal id
+is_or_not_add_approval: YES vote or cancel YES vote
 ```
 
 <h3> 2.4.4 Cancel Proposal </h3>
 
-Proposal creator can cancel the proposal before it is passed.  
+Proposal creator can cancel the proposal before it is passed.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 ```text
 deleteProposal id
 id: proposal id
@@ -108,38 +108,38 @@ id: proposal id
 
 <h3> 2.4.5 Query Proposal </h3>
 
-- Query all the proposals list (ListProposals)  
-- Query all the proposals list by pagination (GetPaginatedProposalList)  
-- Query a proposal by proposal id (GetProposalById)  
+- Query all the proposals list (ListProposals)
+- Query all the proposals list by pagination (GetPaginatedProposalList)
+- Query a proposal by proposal id (GetProposalById)
 
-For more api detail, please refer to [Tron-http](Tron-http.md)  
+For more api detail, please refer to [Tron-http](Tron-http.md)
 
 # 3. Account Model
 
 <h2> 3.1 Introduction </h2>
 
-TRON uses account model. An account's identity is address, it needs private key signature to operate an account. An account has many attributes, like TRX balance, tokens balance, bandwidth, etc. TRX and tokens can be transfered from account to account and it costs bandwidth. An account can also issue a smart contract, apply to become a super representative candidate, vote, etc. All TRON's activities are based on account.
+TRON uses account model. An account's identity is address, it needs private key signature to operate an account. An account has many attributes, like TRX balance, tokens balance, bandwidth, etc. TRX and tokens can be transferred from account to account and it costs bandwidth. An account can also issue a smart contract, apply to become a super representative candidate, vote, etc. All TRON's activities are based on account.
 
 <h2> 3.2 How to Create an Account </h2>
 
-1.&nbsp;Use a wallet to generate the address and private key. To active the account, you need to transfer TRX or transfer token to the new created account. [generate an account](https://tronscan.org/#/wallet/new)
+1.&nbsp;Use a wallet to generate the address and private key. To activate the account, you need to transfer TRX or transfer token to the new created account. [generate an account](https://tronscan.org/#/wallet/new)
 
-2.&nbsp;Use an account already existed in TRON network to create an account   
+2.&nbsp;Use an account already existed in TRON network to create an account
 
 <h2> 3.3 Key-pair Generation Algorithm </h2>
-Tron signature algorithm is ECDSA, curve used is SECP256K1. Private key is a random bumber, public key is a point in the elliptic curve. The process is: first generate a random number d to be the private key, then caculate P = d * G as the public key, G is the elliptic curve base point.
+Tron signature algorithm is ECDSA, curve used is SECP256K1. Private key is a random bumber, public key is a point in the elliptic curve. The process is: first generate a random number d to be the private key, then calculate P = d * G as the public key, G is the elliptic curve base point.
 
 <h2> 3.4 Address Format </h2>
-Use the public key P as the input, by SHA3 get the result H. The length of the public key is 64 bytes, SHA3 uses Keccak256. Use the last 20 bytes of H, and add a byte of 0x41 in front of it, then the address come out. Do basecheck to address, here is the final address. All addresses start with 'T'.   
+Use the public key P as the input, by SHA3 get the result H. The length of the public key is 64 bytes, SHA3 uses Keccak256. Use the last 20 bytes of H, and add a byte of 0x41 in front of it, then the address comes out. Do basecheck to address, here is the final address. All addresses start with 'T'.
 
-basecheck process: first do sha256 caculation to address to get h1, then do sha256 to h1 to get h2, use the first 4 bytes as check to add it to the end of the address to get address||check, do base58 encode to address||check to get the final result.  
+basecheck process: first do sha256 calculation to address to get h1, then do sha256 to h1 to get h2, use the first 4 bytes as check to add it to the end of the address to get address||check, do base58 encode to address||check to get the final result.
 
-Character map:  
-ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"  
+Character map:
+ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 <h2> 3.5 Signature </h2>
-Signature introduction, please refer to:  
-[https://github.com/tronprotocol/Documentation/blob/fix_http/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E4%BA%A4%E6%98%93%E7%AD%BE%E5%90%8D%E6%B5%81%E7%A8%8B.md]( 
+Signature introduction, please refer to:
+[https://github.com/tronprotocol/Documentation/blob/fix_http/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E4%BA%A4%E6%98%93%E7%AD%BE%E5%90%8D%E6%B5%81%E7%A8%8B.md](
 https://github.com/tronprotocol/Documentation/blob/fix_http/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E4%BA%A4%E6%98%93%E7%AD%BE%E5%90%8D%E6%B5%81%E7%A8%8B.md)
 
 # 4. Network Node
@@ -149,9 +149,9 @@ Super Representative(abbr: SR) is the block producer in TRON network, there are 
 <h3> 4.1.2 SuperNode Deployment </h3>
 [SuperNode Deployment](https://github.com/tronprotocol/java-tron#running-a-super-representative-node-for-mainnet)
 <h3> 4.1.3 Recommended Hardware Configuration </h3>
-minimum requirement:  
-CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T  
-Recommended requirement:  
+minimum requirement:
+CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T
+Recommended requirement:
 CPU: > 64 cores RAM: > 64G, Bandwidth: > 500M, Disk: > 20T
 
 <h2> 4.2 FullNode </h2>
@@ -160,9 +160,9 @@ FullNode has the complete block chain data, can update data in real time. It can
 <h3> 4.2.2 FullNode Deployment </h3>
 please refer to [TRON-Deployment](https://github.com/tronprotocol/tron-deployment)
 <h3> 4.2.3 Recommended Hardware Configuration </h3>
-Minimum requirement:    
-CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T   
-Recommended requirement:  
+Minimum requirement:
+CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T
+Recommended requirement:
 CPU: > 64 cores RAM: > 64G, Bandwidth: > 500M, Disk: > 20T
 
 <h2> 4.3 SolidityNode </h2>
@@ -171,9 +171,9 @@ SolidityNode only synchronize solidified blocks data from the fullNode it specif
 <h3> 4.3.2 SolidityNode Deployment </h3>
 Please refer to [TRON-Deployment](https://github.com/tronprotocol/tron-deployment)
 <h3> 4.3.3 Recommended Hardware Configuration </h3>
-Minimum requirement:    
-CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T   
-Recommended requirement:  
+Minimum requirement:
+CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T
+Recommended requirement:
 CPU: > 64 cores RAM: > 64G, Bandwidth: > 500M, Disk: > 20T
 
 <h2> 4.4 TRON Network Instructure </h2>
@@ -181,172 +181,172 @@ TRON network uses Peer-to-Peer(P2P) network instructure, all nodes status equal.
 ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/network.png)
 
 <h2> 4.5 FullNode and SolidityNode Fast Deployment </h2>
-Download fast deployment script, run the script according to different types of node.   
+Download fast deployment script, run the script according to different types of node.
 please refer to [Node Fast Deployment](https://github.com/tronprotocol/tron-deployment#deployment-of-soliditynode-on-the-one-host)
 
 <h2> 4.6 MainNet, TestNet, PrivateNet </h2>
 
-MainNet, TestNet, PrivateNet all use the same code, only the node start configuration varies.  
+MainNet, TestNet, PrivateNet all use the same code, only the node start configuration varies.
 
 <h3> 4.6.1 MainNet </h3>
 
-[MainNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/main_net_config.conf)  
+[MainNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/main_net_config.conf)
 
 <h3> 4.6.2 TestNet </h3>
 
-[TestNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/test_net_config.conf)  
+[TestNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/test_net_config.conf)
 
 <h3> 4.6.3 PrivateNet </h3>
 
 <h4> 4.6.3.1 Preconditions </h4>
 
-- at least two accounts [generate an account](https://tronscan.org/#/wallet/new)  
-- at least deploy one SuperNode to produce blocks  
-- deploy serval FullNodes to synchronize blocks and broadcast transactions  
-- SuperNode and FullNode comprise the private network  
+- at least two accounts [generate an account](https://tronscan.org/#/wallet/new)
+- at least deploy one SuperNode to produce blocks
+- deploy serval FullNodes to synchronize blocks and broadcast transactions
+- SuperNode and FullNode comprise the private network
 
 <h5> 4.6.3.2 Deployment </h5>
 
 <h6> 4.6.3.2.1 Step 1: SuperNode Deployment </h6>
 
- 1.&nbsp;download private_net_config.conf  
+ 1.&nbsp;download private_net_config.conf
 
 ```text
 wget https://github.com/tronprotocol/tron-deployment/blob/master/private_net_config.conf
 ```
- 2.&nbsp;add your private key in localwitness  
- 3.&nbsp;set genesis.block.witnesses as the private key's corresponding address  
- 4.&nbsp;set p2p.version, any positive integer but 11111  
- 5.&nbsp;set the first SR needSyncCheck = false, others can be set true  
- 6.&nbsp;set node.discovery.enable = true  
- 7.&nbsp;run the script  
+ 2.&nbsp;add your private key in localwitness
+ 3.&nbsp;set genesis.block.witnesses as the private key's corresponding address
+ 4.&nbsp;set p2p.version, any positive integer but 11111
+ 5.&nbsp;set the first SR needSyncCheck = false, others can be set true
+ 6.&nbsp;set node.discovery.enable = true
+ 7.&nbsp;run the script
 
 ```text
 nohup java -Xmx6g -XX:+HeapDumpOnOutOfMemoryError -jar FullNode.jar  --witness  -c private_net_config.conf
 
-command line parameters introduction:  
---witness: start witness function, i.e.: --witness  
---log-config: specify the log configuration file path, i.e.: --log-config logback.xml  
--c: specify the configuration file path, i.e.: -c config.conf 
+command line parameters introduction:
+--witness: start witness function, i.e.: --witness
+--log-config: specify the log configuration file path, i.e.: --log-config logback.xml
+-c: specify the configuration file path, i.e.: -c config.conf
 ```
- 
- The usage of the log file:  
- You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:  
+
+ The usage of the log file:
+ You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:
  <logger name="net" level="WARN"/>
- The parameters in configuration file that need to modify:  
- localwitness:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/localwitness.jpg)  
- witnesses:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/witness.png)  
- version:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)  
- enable:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)  
+ The parameters in configuration file that need to modify:
+ localwitness:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/localwitness.jpg)
+ witnesses:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/witness.png)
+ version:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)
+ enable:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)
 
 
 <h6> 4.6.3.2.2 Step 2: FullNode Deployment </h6>
- 1.&nbsp;Download private_net_config.conf  
+ 1.&nbsp;Download private_net_config.conf
 
 ```text
-wget https://github.com/tronprotocol/tron-deployment/blob/master/private_net_config.conf 
+wget https://github.com/tronprotocol/tron-deployment/blob/master/private_net_config.conf
 ```
- 2.&nbsp;set seed.node ip.list with SR's ip and port  
- 3.&nbsp;set p2p.version the same as SuperNode's p2p.version   
- 4.&nbsp;set genesis.block the same as genesis.block  
- 5.&nbsp;set needSyncCheck true   
- 6.&nbsp;set node.discovery.enable true   
- 7.&nbsp;run the script  
+ 2.&nbsp;set seed.node ip.list with SR's ip and port
+ 3.&nbsp;set p2p.version the same as SuperNode's p2p.version
+ 4.&nbsp;set genesis.block the same as genesis.block
+ 5.&nbsp;set needSyncCheck true
+ 6.&nbsp;set node.discovery.enable true
+ 7.&nbsp;run the script
 
 ```text
  nohup java -Xmx6g -XX:+HeapDumpOnOutOfMemoryError -jar FullNode.jar  --witness  -c private_net_config.conf
 
- command lines parameters  
- --witness: start witness function，i.e.: --witness  
- --log-config: specify the log configuration file path, i.e.: --log-config logback.xml  
+ command lines parameters
+ --witness: start witness function，i.e.: --witness
+ --log-config: specify the log configuration file path, i.e.: --log-config logback.xml
  -c: specify the configuration file path, i.e.: -c config.conf
 ```
 
- The usage of the log file:  
- You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:  
+ The usage of the log file:
+ You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:
  <logger name="net" level="WARN"/>
- The parameters in configuration file that need to modify:    
- ip.list:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/ip_list.png)  
- p2p.version:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)  
- genesis.block:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/genesis_block.png)  
- needSyncCheck:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/need_sync_check.png)  
- node.discovery.enable:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)  
- 
+ The parameters in configuration file that need to modify:
+ ip.list:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/ip_list.png)
+ p2p.version:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)
+ genesis.block:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/genesis_block.png)
+ needSyncCheck:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/need_sync_check.png)
+ node.discovery.enable:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)
+
 <h2> 4.7 DB Engine </h2>
 <h3> 4.7.1 Rocksdb </h3>
 <h4> 4.7.1.1 Configuration </h4>
- Use rocksdb as the data storage engine, need to set db.engine to "ROCKSDB"  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/db_engine.png)  
- Note: rocksdb only support db.version=2, do not support db.version=1  
+ Use rocksdb as the data storage engine, need to set db.engine to "ROCKSDB"
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/db_engine.png)
+ Note: rocksdb only support db.version=2, do not support db.version=1
 
- The optimization parameters rocksdb support:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/rocksdb_tuning_parameters.png)  
+ The optimization parameters rocksdb support:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/rocksdb_tuning_parameters.png)
 
 <h4> 4.7.1.2 Use rocksdb's data backup function </h4>
- Choose rocksdb to be the data storage engine, you can use it's data backup funchtion while running  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/db_backup.png)  
- Note: FullNode can use data backup function. In order not to affect SuperNode's block producing performance, SuperNode does not support backup service, but SuperNode's backup service node can use this function.  
+ Choose rocksdb to be the data storage engine, you can use it's data backup function while running
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/db_backup.png)
+ Note: FullNode can use data backup function. In order not to affect SuperNode's block producing performance, SuperNode does not support backup service, but SuperNode's backup service node can use this function.
 
 <h4> 4.7.1.3 Convert leveldb data to rocksdb data </h4>
- The data storage structure of leveldb and rocksdb is not compatible, please make sure the node use the same type of data engine all the time. We provide data conversion script which can convert leveldb data to rocksdb data.  
+ The data storage structure of leveldb and rocksdb is not compatible, please make sure the node use the same type of data engine all the time. We provide data conversion script which can convert leveldb data to rocksdb data.
 
- Usage:  
+ Usage:
 ```text
  cd to the source code root directory
  ./gradlew build   #build the source code
  java -jar build/libs/DBConvert.jar  #run data conversion command
 ```
- Note: If the node's data storage directory is self-defined, before run DBConvert.jar, you need to add the following parameters:  
+ Note: If the node's data storage directory is self-defined, before run DBConvert.jar, you need to add the following parameters:
 
- **src_db_path**: specify LevelDB source directory, default output-directory/database  
- **dst_db_path**: specify RocksDb source directory, default output-directory-dst/database  
- 
-Example, if you run the script like this:  
+ **src_db_path**: specify LevelDB source directory, default output-directory/database
+ **dst_db_path**: specify RocksDb source directory, default output-directory-dst/database
+
+Example, if you run the script like this:
 ```text
  nohup java -jar FullNode.jar -d your_database_dir &
 ```
-Then, you should run DBConvert.jar this way:  
+Then, you should run DBConvert.jar this way:
 ```text
  java -jar build/libs/DBConvert.jar  your_database_dir/database  output-directory-dst/database
 ```
- Note: You have to stop the running of the node, and then to run the data conversion script.  
+ Note: You have to stop the running of the node, and then to run the data conversion script.
 
- If you do not want to stop the running of the node for too long, after node is shut down, you can copy leveldb's output-directory to the new directory, and then restart the node. Run DBConvert.jar in the previous directory of the new directory, and specify the parameters: `src_db_path`和`dst_db_path`.   
+ If you do not want to stop the running of the node for too long, after node is shut down, you can copy leveldb's output-directory to the new directory, and then restart the node. Run DBConvert.jar in the previous directory of the new directory, and specify the parameters: `src_db_path`和`dst_db_path`.
 
-Example:  
+Example:
 ```text
  cp -rf output-directory /tmp/output-directory
  cd /tmp
  java -jar DBConvert.jar output-directory/database  output-directory-dst/database
 ```
- All the whole data conversion process may take 10 hours.  
-  
+ All the whole data conversion process may take 10 hours.
+
 <h4> 4.7.1.4 rocksdb vs leveldb  </h4>
-You can refer to:  
-[rocksdb vs leveldb](https://github.com/tronprotocol/documentation/blob/master/TRX_CN/Rocksdb_vs_Leveldb.md)  
-[ROCKSDB vs LEVELDB](https://github.com/tronprotocol/documentation/blob/master/TRX/Rocksdb_vs_Leveldb.md)  
+You can refer to:
+[rocksdb vs leveldb](https://github.com/tronprotocol/documentation/blob/master/TRX_CN/Rocksdb_vs_Leveldb.md)
+[ROCKSDB vs LEVELDB](https://github.com/tronprotocol/documentation/blob/master/TRX/Rocksdb_vs_Leveldb.md)
 
 # 5. Smart Contract
 <h2> 5.1 TRON Smart Contract Introduction </h2>
 
-Smart contract is a computerized transaction protocol that automatically implements its terms. Smart contract is the same as common contract, they all define the terms and rules related to the participants. Once the contract is started, it can runs in the way it is designed.   
+Smart contract is a computerized transaction protocol that automatically implements its terms. Smart contract is the same as common contract, they all define the terms and rules related to the participants. Once the contract is started, it can run in the way it is designed.
 
 TRON smart contract support Solidity language in (Ethereum). Currently recommend Solidity language version is 0.4.24 ~ 0.4.25. Write a smart contract, then build the smart contract and deploy it to TRON network. When the smart contract is triggered, the corresponding function will be executed automatically.
 
 <h2> 5.2 TRON Smart Contract Features </h2>
-TRON virtual machine is based on Ethereum solidity language, it also has TRON's own features.  
+TRON virtual machine is based on Ethereum solidity language, it also has TRON's own features.
 
 <h3> 5.2.1 Smart Contract </h3>
-TRON VM is compatible with Ethereum's smart contract, using protobuf to define the content of the contract:  
+TRON VM is compatible with Ethereum's smart contract, using protobuf to define the content of the contract:
 
     message SmartContract {
       message ABI {
@@ -392,17 +392,17 @@ TRON VM is compatible with Ethereum's smart contract, using protobuf to define t
       string name = 7；
       int64 origin_energy_limit = 8;
     }
-    
-origin_address: smart contract creator address  
-contract_address: smart contract address  
-abi: the api information of the all the function of the smart contract  
-bytecode: smart contract byte code  
-call_value: TRX transferred into smart contract while call the contract  
-consume_user_resource_percent: resource consumption percentage set by the developer  
-name: smart contract name  
-origin_energy_limit: energy consumption of the developer limit in one call, must greater than 0. For the old contracts, if this parameter is not set, it will be set 0, developer can use updateEnergyLimit api to update this parameter (must greater than 0) 
 
-Through other two grpc message types CreateSmartContract and TriggerSmartContract to create and use smart contract.  
+origin_address: smart contract creator address
+contract_address: smart contract address
+abi: the api information of the all the function of the smart contract
+bytecode: smart contract byte code
+call_value: TRX transferred into smart contract while call the contract
+consume_user_resource_percent: resource consumption percentage set by the developer
+name: smart contract name
+origin_energy_limit: energy consumption of the developer limit in one call, must greater than 0. For the old contracts, if this parameter is not set, it will be set 0, developer can use updateEnergyLimit api to update this parameter (must greater than 0)
+
+Through other two grpc message types CreateSmartContract and TriggerSmartContract to create and use smart contracts.
 
 <h3> 5.2.2 The Usage of the Function of Smart Contract </h3>
 
@@ -410,68 +410,68 @@ Through other two grpc message types CreateSmartContract and TriggerSmartContrac
 
 There are two types of function according to whether any change will be made to the properties on the chain: constant function and inconstant function
 Constant function uses view/pure/constant to decorate, will return the result on the node it is called and not be broadcasted in the form of a transaction
-Inconstant function will be broadcasted in the form of a transaction while be called, the function will change the data on the chain, such as transfer, changing the value of the internal variables of contracts, etc.  
+Inconstant function will be broadcasted in the form of a transaction while being called, the function will change the data on the chain, such as transfer, changing the value of the internal variables of contracts, etc.
 
-Note: If you use create command inside a contract (CREATE instruction), even use view/pure/constant to decorate the dynamically created contract function, this function will still be treated as inconstant function, be dealt in the form of transaction.  
+Note: If you use create command inside a contract (CREATE instruction), even use view/pure/constant to decorate the dynamically created contract function, this function will still be treated as inconstant function, be dealt in the form of transaction.
 
 2.&nbsp;message calls
 
-Message calls can call the functions of other contracts, also can transfer TRX to the accounts of contract and none-contract. Like the common TRON triggercontract, Message calls have initiator, recipient, data, transfer amount, fees and return attributes. Every message call can generate a new one recursively. Contract can define the distribution of the remaining energy in the internal message call. If it comes with OutOfEnergyException in the internal message call, it will return false, but not error. In the meanwhile, only the gas sent with the internal message call will be consumed, if energy is not specified in call.value(energy), all the remaining energy will be used.  
+Message calls can call the functions of other contracts, also can transfer TRX to the accounts of contract and none-contract. Like the common TRON triggercontract, Message calls have initiator, recipient, data, transfer amount, fees and return attributes. Every message call can generate a new one recursively. Contract can define the distribution of the remaining energy in the internal message call. If it comes with OutOfEnergyException in the internal message call, it will return false, but not error. In the meanwhile, only the gas sent with the internal message call will be consumed, if energy is not specified in call.value(energy), all the remaining energy will be used.
 
 3.&nbsp;delegate call/call code/libary
 
-There is a special type of message call, delegate call. The difference with common message call is the code of the target address will be run in the context of the contract that initiates the call, msg.sender and msg.value remain unchanged. This means a contract can dynamically loadcode from another address while running. Storage, current address and balance all point to the contract that initiates the call, only the code is get from the address being called. This gives Solidity the ability to achieve the 'lib' function: the reusable code lib can be put in the storage of a contract to implement complex data structure library.  
+There is a special type of message call, delegate call. The difference with common message call is the code of the target address will be run in the context of the contract that initiates the call, msg.sender and msg.value remain unchanged. This means a contract can dynamically load code from another address while running. Storage, current address and balance all point to the contract that initiates the call, only the code is get from the address being called. This gives Solidity the ability to achieve the 'lib' function: the reusable code lib can be put in the storage of a contract to implement complex data structure library.
 
 4.&nbsp;CREATE command
 
-This command will create a new contract with a new address. The only difference with Ethereum is the newly generated TRON address used the smart contract creation transaction id and the hash of nonce called combined. Different from Ethereum, the defination of nonce is the comtract sequence number of the creation of the root call. Even there are many CREATE commands calls, contract number in sequence from 1. Refer to the source code for more detail. 
-Note: Different from creating a contract by grpc's deploycontract, contract created by CREATE command does not store contract abi.  
+This command will create a new contract with a new address. The only difference with Ethereum is the newly generated TRON address used the smart contract creation transaction id and the hash of nonce called combined. Different from Ethereum, the definition of nonce is the comtract sequence number of the creation of the root call. Even there are many CREATE commands calls, contract number in sequence from 1. Refer to the source code for more detail.
+Note: Different from creating a contract by grpc's deploycontract, contract created by CREATE command does not store contract abi.
 
 5.&nbsp;built-in function and built-in function attribute (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
 
-1）TVM is compatible with solidity language's transfer format, including:  
-- accompany with constructor to call transfer  
-- accompany with internal function to call transfer  
-- use transfer/send/call/callcode/delegatecall to call transfer  
+1）TVM is compatible with solidity language's transfer format, including:
+- accompany with constructor to call transfer
+- accompany with internal function to call transfer
+- use transfer/send/call/callcode/delegatecall to call transfer
 
-Note: TRON's smart contract is different from TRON's system contract, if the transfer to address does not exist it can not create an account by smart contract transfer.  
+Note: TRON's smart contract is different from TRON's system contract, if the transfer to address does not exist it can not create an account by smart contract transfer.
 
-2）Different accouts vote for SuperNode (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-3）SuperNode gets all the reward (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-4）SuperNode approves or disappoves the proposal (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-5）SuperNode proposes a proposal (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-6）SuperNode deletes  a proposal (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-7）TRON byte address converts to solidity address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-8）TRON string address converts to solidity address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-9）Send token to target address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-10）Query token amount of target address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)  
-11）Compatible with all the built-in functions of Ethereum  
+2）Different accounts vote for SuperNode (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+3）SuperNode gets all the reward (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+4）SuperNode approves or disapproves the proposal (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+5）SuperNode proposes a proposal (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+6）SuperNode deletes  a proposal (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+7）TRON byte address converts to solidity address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+8）TRON string address converts to solidity address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+9）Send token to target address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+10）Query token amount of target address (Since Odyssey-v3.1.1, TVM built-in function is not supported temporarily)
+11）Compatible with all the built-in functions of Ethereum
 
 Note: Ethereum's RIPEMD160 function is not recommended, because the return of TRON is a hash result based on TRON's sha256, not an accurate Ethereum RIPEMD160.
- 
+
 <h3> 5.2.3 Contract Address Using in Solidity Language </h3>
 
-Ethereum VM address is 20 bytes, but TRON's VM address is 21 bytes.  
+Ethereum VM address is 20 bytes, but TRON's VM address is 21 bytes.
 
-1.&nbsp;address conversion  
+1.&nbsp;address conversion
 
-Need to convert TRON's address while using in solidity (recommended):  
-```text    
+Need to convert TRON's address while using in solidity (recommended):
+```text
 /**
      *  @dev    convert uint256 (HexString add 0x at beginning) tron address to solidity address type
      *  @param  tronAddress uint256 tronAddress, begin with 0x, followed by HexString
      *  @return Solidity address type
 */
-     
+
 function convertFromTronInt(uint256 tronAddress) public view returns(address){
         return address(tronAddress);
 }
 ```
-This is similar with the grammar of the conversion from other types converted to address type in Ethereum.   
+This is similar with the grammar of the conversion from other types converted to address type in Ethereum.
 
-2.&nbsp;address judgement  
+2.&nbsp;address judgement
 
-Solidity has address constant judgement, if using 21 bytes address the compiler will throw out an error, so you should use 20 bytes address, like:  
+Solidity has address constant judgement, if using 21 bytes address the compiler will throw out an error, so you should use 20 bytes address, like:
 ```text
 function compareAddress(address tronAddress) public view returns (uint256){
         // if (tronAddress == 0x41ca35b7d915458ef540ade6068dfe2f44e8fa733c) { // compile error
@@ -482,11 +482,11 @@ function compareAddress(address tronAddress) public view returns (uint256){
         }
 }
 ```
-But if you are using wallet-cli, you can use 21 bytes address, like 0000000000000000000041ca35b7d915458ef540ade6068dfe2f44e8fa733c    
+But if you are using wallet-cli, you can use 21 bytes address, like 0000000000000000000041ca35b7d915458ef540ade6068dfe2f44e8fa733c
 
-3.&nbsp;variable assignment  
+3.&nbsp;variable assignment
 
-Solidity has address constant assignment, if using 21 bytes address the compiler will throw out an error, so you should use 20 bytes address, like:  
+Solidity has address constant assignment, if using 21 bytes address the compiler will throw out an error, so you should use 20 bytes address, like:
 ```text
 function assignAddress() public view {
         // address newAddress = 0x41ca35b7d915458ef540ade6068dfe2f44e8fa733c; // compile error
@@ -494,49 +494,49 @@ function assignAddress() public view {
         // do something
 }
 ```
-If you want to use TRON address of string type (TLLM21wteSPs4hKjbxgmH1L6poyMjeTbHm) please refer to (2-4-7,2-4-8).  
+If you want to use TRON address of string type (TLLM21wteSPs4hKjbxgmH1L6poyMjeTbHm) please refer to (2-4-7,2-4-8).
 
 <h3> 5.2.4 The Special Constants Differ from Ethereum </h3>
 
-**Currency**  
+**Currency**
 
-Like solidity supports ETH, TRON VM supports trx and sun, 1 trx = 1000000 sun, case sensitive, only support lower case. tron-studio supports trx and sun, remix does not support trx and sun.   
+Like solidity supports ETH, TRON VM supports trx and sun, 1 trx = 1000000 sun, case sensitive, only support lower case. tron-studio supports trx and sun, remix does not support trx and sun.
 We recommend to use tron-studio instead of remix to build TRON smart contract.
 
-**Block**  
+**Block**
 
-- block.blockhash (uint blockNumber) returns (bytes32): specified block hash, can only apply to the latest 256 blocks and current block excluded  
-- block.coinbase (address): SuperNode address that produced the current block  	
-- block.difficulty (uint): current block difficulty, not recommended, set 0  
-- block.gaslimit (uint): current block gas limit, not supported, set 0  
-- block.number (uint): current block number  
-- block.timestamp (uint): current block timestamp  
-- gasleft() returns (uint256): remaining gas  
-- msg.data (bytes): complete call data  
-- msg.gas (uint): remaining gas - since 0.4.21, not recommended, replaced by gesleft()  
-- msg.sender (address): message sender (current call)  
-- msg.sig (bytes4): first 4 bytes of call data (function identifier)  
-- msg.value (uint): the amount of SUN send with message  
-- now (uint): current block timestamp (block.timestamp)  
-- tx.gasprice (uint): the gas price of transaction, not recommended, set 0  
-- tx.origin (address): transaction initiator  
+- block.blockhash (uint blockNumber) returns (bytes32): specified block hash, can only apply to the latest 256 blocks and current block excluded
+- block.coinbase (address): SuperNode address that produced the current block
+- block.difficulty (uint): current block difficulty, not recommended, set 0
+- block.gaslimit (uint): current block gas limit, not supported, set 0
+- block.number (uint): current block number
+- block.timestamp (uint): current block timestamp
+- gasleft() returns (uint256): remaining gas
+- msg.data (bytes): complete call data
+- msg.gas (uint): remaining gas - since 0.4.21, not recommended, replaced by gesleft()
+- msg.sender (address): message sender (current call)
+- msg.sig (bytes4): first 4 bytes of call data (function identifier)
+- msg.value (uint): the amount of SUN send with message
+- now (uint): current block timestamp (block.timestamp)
+- tx.gasprice (uint): the gas price of transaction, not recommended, set 0
+- tx.origin (address): transaction initiator
 
 <h2> 5.3 Energy Introduction </h2>
-Each command of smart contract consume system resource while running, we use 'Energy' as the unit of the consumption of the resource.  
+Each command of smart contract consume system resource while running, we use 'Energy' as the unit of the consumption of the resource.
 
 <h3> 5.3.1 How to Get Energy </h3>
 
-Freeze TRX to get energy.  
+Freeze TRX to get energy.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 
 ```text
 freezeBalance frozen_balance frozen_duration [ResourceCode:0 BANDWIDTH,1 ENERGY]
 ```
 
-Freeze TRX to get energy, energy obtained = user's TRX frozen amount / total amount of frozen TRX in TRON * 50_000_000_000.  
+Freeze TRX to get energy, energy obtained = user's TRX frozen amount / total amount of frozen TRX in TRON * 50_000_000_000.
 
-Example:  
+Example:
 
 ```text
 If there are only two users, A freezes 2 TRX, B freezes 2 TRX
@@ -551,11 +551,11 @@ B: 20_000_000_000 and energy_limit is 20_000_000_000
 B: 10_000_000_000 and energy_limit is 10_000_000_000
 ```
 
-** Energy Recovery **  
+** Energy Recovery **
 
-The energy consumed will reduce to 0 smoothly within 24 hours.  
+The energy consumed will reduce to 0 smoothly within 24 hours.
 
-Example:  
+Example:
 
 ```text
 at one moment, A has used 72_000_000 Energy
@@ -573,61 +573,61 @@ one hour later, the energy consumption amount will be 72_000_000 - (72_000_000 *
 
 ***
 
-Set a rational fee limit can guarantee the smart contract execution. And if the execution of the contract cost great energy, it will not consume too much energy from the caller. Before you set fee limit, you need to know several conception:  
+Set a rational fee limit can guarantee the smart contract execution. And if the execution of the contract cost great energy, it will not consume too much energy from the caller. Before you set fee limit, you need to know several conception:
 
-1.&nbsp;The legal fee limit is a integer between 0 - 10^9, unit is SUN.  
+1.&nbsp;The legal fee limit is a integer between 0 - 10^9, unit is SUN.
 
-2.&nbsp;Different smart contracts consume different amount of energy due to their complexity. The same trigger in the same contract almost consumes the same amount fo energy[1]. When the contract is triggered, the commands will be excuted one by one and consume energy. If it reaches the fee limit, commands will fail to be excuted, and energy is not refundable.  
+2.&nbsp;Different smart contracts consume different amount of energy due to their complexity. The same trigger in the same contract almost consumes the same amount fo energy[1]. When the contract is triggered, the commands will be executed one by one and consume energy. If it reaches the fee limit, commands will fail to be executed, and energy is not refundable.
 
-3.&nbsp;Currently fee limit only refers to the energy converted to SUN that will be consumed from the caller[2]. The energy consumed by triggering contract also includes developer's share.  
+3.&nbsp;Currently fee limit only refers to the energy converted to SUN that will be consumed from the caller[2]. The energy consumed by triggering contract also includes developer's share.
 
-4.&nbsp;For a vicious contract, if it encounters execution timeout or bug crash, all it's energy will be consumed.  
+4.&nbsp;For a vicious contract, if it encounters execution timeout or bug crash, all it's energy will be consumed.
 
-5.&nbsp;Developer may undertake a proportion of energy consumption(like 90%). But if the developer's energy is not enough for consumption, the rest of the energy consumption will be undertaken by caller completely. Within the fee limit range, if the caller does not have enough energy, then it will burn equivalent amount of TRX [2].  
+5.&nbsp;Developer may undertake a proportion of energy consumption(like 90%). But if the developer's energy is not enough for consumption, the rest of the energy consumption will be undertaken by caller completely. Within the fee limit range, if the caller does not have enough energy, then it will burn equivalent amount of TRX [2].
 
-To encourage caller to trigger the contract, usually developer has enough energy.  
+To encourage caller to trigger the contract, usually developer has enough energy.
 
-** Example **  
+** Example **
 
-How to estimate the fee limit:  
+How to estimate the fee limit:
 
-Assume contract C's last execution consumes 18000 Energy, so estimate the energy consumption limit to be 20000 Energy[3]  
+Assume contract C's last execution consumes 18000 Energy, so estimate the energy consumption limit to be 20000 Energy[3]
 
-According to the frozen TRX amount and energy conversion, assume 1 TRX = 400 energy. 
+According to the frozen TRX amount and energy conversion, assume 1 TRX = 400 energy.
 
-When to burn TRX, 1 TRX = 10000 energy[4]  
+When to burn TRX, 1 TRX = 10000 energy[4]
 
-Assume developer undertake 90% energy consumption, and developer has enough energy.  
- 
-Then the way to estimate the fee limit is:   
+Assume developer undertake 90% energy consumption, and developer has enough energy.
 
-1). A = 20000 energy * (1 TRX / 400 energy) = 50 TRX = 50_000_000 SUN,  
-2). B = 20000 energy * (1 TRX / 10000 energy) = 2 TRX = 2_000_000 SUN,  
-3). Take the greater number of A and B, which is 50_000_000 SUN,  
-4). Developer undertakes 90% energy consumption, caller undertakes 10% energy consumption,  
+Then the way to estimate the fee limit is:
 
-So, the caller is suggested to set fee limit to 50_000_000 SUN * 10% = 5_000_000 SUN  
+1). A = 20000 energy * (1 TRX / 400 energy) = 50 TRX = 50_000_000 SUN,
+2). B = 20000 energy * (1 TRX / 10000 energy) = 2 TRX = 2_000_000 SUN,
+3). Take the greater number of A and B, which is 50_000_000 SUN,
+4). Developer undertakes 90% energy consumption, caller undertakes 10% energy consumption,
 
-Note:  
+So, the caller is suggested to set fee limit to 50_000_000 SUN * 10% = 5_000_000 SUN
 
-[1] The energy consumption of each execution may fluctuate slightly due to the situation of all the nodes.  
-[2] TRON may change this policy.  
-[3] The estimated energy consumption limit for the next execution should be greater than the last one.  
-[4] 1 TRX = 10^4 energy is a fixed number for burning TRX to get energy, TRON may change it in future.  
+Note:
+
+[1] The energy consumption of each execution may fluctuate slightly due to the situation of all the nodes.
+[2] TRON may change this policy.
+[3] The estimated energy consumption limit for the next execution should be greater than the last one.
+[4] 1 TRX = 10^4 energy is a fixed number for burning TRX to get energy, TRON may change it in future.
 
 <h3> 5.3.3 Energy Calculation (Developer Must Read)  </h3>
 
-1.&nbsp;In order to punish the vicious developer, for the abnormal contract, if the execution times out (more than 50ms) or quits due to bug (revert not included), the maximum available energy will be deducted. If the contract runs normally or revert, only the energy needed for the execution of the commands will be deducted.  
+1.&nbsp;In order to punish the vicious developer, for the abnormal contract, if the execution times out (more than 50ms) or quits due to bug (revert not included), the maximum available energy will be deducted. If the contract runs normally or revert, only the energy needed for the execution of the commands will be deducted.
 
-2.&nbsp;Developer can set the proportion of the energy consumption it undertakes during the execution, this proportion cna be changed later. If the developer's energy is not enough, it will consume the caller's energy.  
+2.&nbsp;Developer can set the proportion of the energy consumption it undertakes during the execution, this proportion cna be changed later. If the developer's energy is not enough, it will consume the caller's energy.
 
-3.&nbsp;Currently, the total energy available when trigger a contract is composed of caller fee limit and developer's share  
+3.&nbsp;Currently, the total energy available when trigger a contract is composed of caller fee limit and developer's share
 
-Note:  
-- If the developer is not sure about whether the contract is normal, do not set caller's energy consumption proportion to 0%, in case all developer's energy will be deducted due to vicious execution[1].  
-- We recommend to set caller's energy consumption proportion to 10% ~ 100%[2]. 
+Note:
+- If the developer is not sure about whether the contract is normal, do not set caller's energy consumption proportion to 0%, in case all developer's energy will be deducted due to vicious execution[1].
+- We recommend to set caller's energy consumption proportion to 10% ~ 100%[2].
 
-** Example 1 **   
+** Example 1 **
 
 A has an account with a balance of 90 TRX(90000000 SUN) and 10 TRX frozen for 100000 energy.
 
@@ -635,73 +635,73 @@ Smart contract C set the caller energy consumption proportion to 100% which mean
 
 A triggers C, the fee limit set is 30000000 (unit SUN, 30 TRX)
 
-So during this trigger the energy A can use is from two parts:  
-- A's energy by freezing TRX;  
-- The energy converted from the amount of TRX burning according to a fixed rate;  
+So during this trigger the energy A can use is from two parts:
+- A's energy by freezing TRX;
+- The energy converted from the amount of TRX burning according to a fixed rate;
 
-If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (30 - 10) TRX = 20 TRX available, so the energy it can keep consuming is 20 TRX / 100 SUN = 200000 energy.   
+If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (30 - 10) TRX = 20 TRX available, so the energy it can keep consuming is 20 TRX / 100 SUN = 200000 energy.
 
-Finally, in this call, the energy A can use is (100000 + 200000) = 300000 energy.  
+Finally, in this call, the energy A can use is (100000 + 200000) = 300000 energy.
 
-If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use. 
+If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use.
 
-If Assert-style error come out, it will consume the whole number of energy set for fee limit.  
+If Assert-style error come out, it will consume the whole number of energy set for fee limit.
 
-Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)  
+Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)
 
-** Example 2 **    
+** Example 2 **
 
-A has an account with a balance of 90 TRX(90000000 SUN) and 10 TRX frozen for 100000 energy.  
+A has an account with a balance of 90 TRX(90000000 SUN) and 10 TRX frozen for 100000 energy.
 
-Smart contract C set the caller energy consumption proportion to 40% which means the developer will pay for the rest 60% energy consumption.  
+Smart contract C set the caller energy consumption proportion to 40% which means the developer will pay for the rest 60% energy consumption.
 
-Developer D freezes 50 TRX to get 500000 energy.  
+Developer D freezes 50 TRX to get 500000 energy.
 
-A triggers C, the fee limit set is 200000000 (unit SUN, 200 TRX).  
+A triggers C, the fee limit set is 200000000 (unit SUN, 200 TRX).
 
-So during this trigger the energy A can use is from three parts:  
-- A's energy by freezing TRX -- X;  
-- The energy converted from the amount of TRX bruning according to a fixed rate -- Y;   
-If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (200 - 10) TRX = 190 TRX available, but A only has 90 TRX left, so the energy it can keep consuming is 90 TRX / 100 SUN = 900000 energy;  
-- D's energy by freezing TRX -- Z;  
+So during this trigger the energy A can use is from three parts:
+- A's energy by freezing TRX -- X;
+- The energy converted from the amount of TRX bruning according to a fixed rate -- Y;
+If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (200 - 10) TRX = 190 TRX available, but A only has 90 TRX left, so the energy it can keep consuming is 90 TRX / 100 SUN = 900000 energy;
+- D's energy by freezing TRX -- Z;
 
-There are two situation:  
-if (X + Y) / 40% >= Z / 60%, the energy A can use is X + Y + Z  
-if (X + Y) / 40% < Z / 60%, the energy A can use is (X + Y) / 40%  
+There are two situation:
+if (X + Y) / 40% >= Z / 60%, the energy A can use is X + Y + Z
+if (X + Y) / 40% < Z / 60%, the energy A can use is (X + Y) / 40%
 
-If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use.   
+If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use.
 
-If Assert-style error comes out, it will consume the whole number of energy set for fee limit. Assert-style error introduction, refer to (https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)  
- 
-Note: when developer create a contract, do not set consume_user_resource_percent to 0, which means developer will undertake all the energy consumption. If Assert-style error comes out, it will consume all energy from the developer itsef.  
+If Assert-style error comes out, it will consume the whole number of energy set for fee limit. Assert-style error introduction, refer to (https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)
 
-Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)  
+Note: when developer create a contract, do not set consume_user_resource_percent to 0, which means developer will undertake all the energy consumption. If Assert-style error comes out, it will consume all energy from the developer itsef.
 
-To avoid unnecessary lost, 10 - 100 is recommended for consume_user_resource_percent.  
+Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)
+
+To avoid unnecessary lost, 10 - 100 is recommended for consume_user_resource_percent.
 
 <h2> 5.4 Smart Contract Development Tool </h2>
 
 <h3> 5.4.1 TronStudio </h3>
 
-Support the build, debug, run, etc. for solidity language written smart contract.  
+Support the build, debug, run, etc. for solidity language written smart contract.
 [https://developers.tron.network/docs/tron-studio-intro](https://developers.tron.network/docs/tron-studio-intro)
 
 <h3> 5.4.2 TronBox </h3>
 
-Support the build, deploy, transplant, etc. for solidity language written smart contract.  
+Support the build, deploy, transplant, etc. for solidity language written smart contract.
 [https://developers.tron.network/docs/tron-box-user-guide](https://developers.tron.network/docs/tron-box-user-guide)
 
 <h3> 5.4.3 TronWeb </h3>
-Provide http api service for the usage of smart contract.  
+Provide http api service for the usage of smart contract.
 [https://developers.tron.network/docs/tron-web-intro](https://developers.tron.network/docs/tron-web-intro)
 
 <h3> 5.4.4 TronGrid </h3>
-Provide smart contract event query service.  
+Provide smart contract event query service.
 [https://developers.tron.network/docs/tron-grid-intro](https://developers.tron.network/docs/tron-grid-intro)
 
 <h2> 5.5 Using Command Lines Tool to Develop Smart Contract </h2>
 
-First you can use TronStudio to write, build and debug the smart contract. After you finish the development of the contract, you can copy it to [SimpleWebCompiler](https://github.com/tronprotocol/tron-demo/tree/master/SmartContractTools/SimpleWebCompiler) to compile to get ABI and ByteCode. We provide a simple data read/write smart contract code example to demonstrate:  
+First you can use TronStudio to write, build and debug the smart contract. After you finish the development of the contract, you can copy it to [SimpleWebCompiler](https://github.com/tronprotocol/tron-demo/tree/master/SmartContractTools/SimpleWebCompiler) to compile to get ABI and ByteCode. We provide a simple data read/write smart contract code example to demonstrate:
 
 ```text
 pragma solidity ^0.4.0;
@@ -712,29 +712,29 @@ contract DataStore {
     function set(uint256 key, uint256 value) public {
         data[key] = value;
     }
-    
+
     function get(uint256 key) view public returns (uint256 value) {
         value = data[key];
     }
 }
 ```
 
-** Start a Private Net **  
+** Start a Private Net **
 
-Make sure the fullnode code has been deployed locally, you can check if 'Produce block successfully' log appears in FullNode/logs/tron.log  
+Make sure the fullnode code has been deployed locally, you can check if 'Produce block successfully' log appears in FullNode/logs/tron.log
 
-** Develop a Smart Contract **  
+** Develop a Smart Contract **
 
-Copy the code example above to remix to debug.  
+Copy the code example above to remix to debug.
 
-** Compile in SimpleWebCompiler for ABI and ByteCode **    
+** Compile in SimpleWebCompiler for ABI and ByteCode **
 
-Copy the code example above to SimpleWebCompiler to get ABI and ByteCode.   
-Because TRON's compiler is a little different from Ethereum, so you can not get ABI and ByteCode by using Remix. But it will soon be supported.  
+Copy the code example above to SimpleWebCompiler to get ABI and ByteCode.
+Because TRON's compiler is a little different from Ethereum, so you can not get ABI and ByteCode by using Remix. But it will soon be supported.
 
-** Using Wallet-cli to Deploy **    
+** Using Wallet-cli to Deploy **
 
-Download Wallet-Cli and build  
+Download Wallet-Cli and build
 
 ```text
 shell
@@ -746,15 +746,15 @@ cd  wallet-cli
 cd  build/libs
 ```
 
-Note: You need to change the node ip and port in config.conf  
+Note: You need to change the node ip and port in config.conf
 
-start wallet-cli  
+start wallet-cli
 
 ```text
 java -jar wallet-cli.jar
 ```
 
-after started, you can use command lines to operate:  
+after started, you can use command lines to operate:
 
 ```text
 importwallet
@@ -765,7 +765,7 @@ login
 getbalance
 ```
 
-deploy contract  
+deploy contract
 
 ```text
 Shell
@@ -788,7 +788,7 @@ deploycontract DataStore [{"constant":false,"inputs":[{"name":"key","type":"uint
 If it is deployed successfully, it will return 'Deploy the contract successfully'
 ```
 
-get the contract address  
+get the contract address
 
 ```text
 Your smart contract address will be: <contract address>
@@ -797,7 +797,7 @@ Your smart contract address will be: <contract address>
 Your smart contract address will be: TTWq4vMEYB2yibAbPV7gQ4mrqTyX92fha6
 ```
 
-call the contract to store data, query data  
+call the contract to store data, query data
 
 ```text
 Shell
@@ -816,36 +816,36 @@ value: The amount of TRX transfer to the contract when trigger
 ## set mapping 1->1
 triggercontract TTWq4vMEYB2yibAbPV7gQ4mrqTyX92fha6 set(uint256,uint256) 1,1 false 1000000  0000000000000000000000000000000000000000000000000000000000000000
 
-## get mapping key = 1 
+## get mapping key = 1
 triggercontract TTWq4vMEYB2yibAbPV7gQ4mrqTyX92fha6 get(uint256) 1 false 1000000  0000000000000000000000000000000000000000000000000000000000000000
 ```
 
-If the function called is constant or view, wallet-cli will return the result directly.  
-If it contains library, before deploy the contract you need to deploy the library first. After you deploy library, you can get the library address, then fill the address in library:address,library:address,...  
+If the function called is constant or view, wallet-cli will return the result directly.
+If it contains library, before deploy the contract you need to deploy the library first. After you deploy library, you can get the library address, then fill the address in library:address,library:address,...
 
 ```text
 # for instance, using remix to get the bytecode of the contract, like:
-608060405234801561001057600080fd5b5061013f806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063f75dac5a14610046575b600080fd5b34801561005257600080fd5b5061005b610071565b6040518082815260200191505060405180910390f35b600073<b>__browser/oneLibrary.sol.Math3__________<\b>634f2be91f6040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b1580156100d357600080fd5b505af41580156100e7573d6000803e3d6000fd5b505050506040513d60208110156100fd57600080fd5b81019080805190602001909291905050509050905600a165627a7a7230582052333e136f236d95e9d0b59c4490a39e25dd3a3dcdc16285820ee0a7508eb8690029  
+608060405234801561001057600080fd5b5061013f806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063f75dac5a14610046575b600080fd5b34801561005257600080fd5b5061005b610071565b6040518082815260200191505060405180910390f35b600073<b>__browser/oneLibrary.sol.Math3__________<\b>634f2be91f6040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b1580156100d357600080fd5b505af41580156100e7573d6000803e3d6000fd5b505050506040513d60208110156100fd57600080fd5b81019080805190602001909291905050509050905600a165627a7a7230582052333e136f236d95e9d0b59c4490a39e25dd3a3dcdc16285820ee0a7508eb8690029
 ```
 
-The address of the library deployed before is: TSEJ29gnBkxQZR3oDdLdeQtQQykpVLSk54  
-When you deploy, you need to use browser/oneLibrary.sol.Math3:TSEJ29gnBkxQZR3oDdLdeQtQQykpVLSk54 as the parameter of deploycontract.  
+The address of the library deployed before is: TSEJ29gnBkxQZR3oDdLdeQtQQykpVLSk54
+When you deploy, you need to use browser/oneLibrary.sol.Math3:TSEJ29gnBkxQZR3oDdLdeQtQQykpVLSk54 as the parameter of deploycontract.
 
 # 6. Built-in Contracts and API
 <h2> 6.1 Built-in Contracts </h2>
-Please refer to:  
+Please refer to:
 [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E6%B3%A2%E5%9C%BA%E5%8D%8F%E8%AE%AE/%E4%BA%A4%E6%98%93%E6%93%8D%E4%BD%9C%E7%B1%BB%E5%9E%8B%E8%AF%B4%E6%98%8E.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E6%B3%A2%E5%9C%BA%E5%8D%8F%E8%AE%AE/%E4%BA%A4%E6%98%93%E6%93%8D%E4%BD%9C%E7%B1%BB%E5%9E%8B%E8%AF%B4%E6%98%8E.md)
 
 <h2> 6.2 GRPC API Introduction </h2>
-Please refer to:  
+Please refer to:
 [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E6%B3%A2%E5%9C%BA%E5%8D%8F%E8%AE%AE/%E6%B3%A2%E5%9C%BA%E9%92%B1%E5%8C%85RPC-API.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E6%B3%A2%E5%9C%BA%E5%8D%8F%E8%AE%AE/%E6%B3%A2%E5%9C%BA%E9%92%B1%E5%8C%85RPC-API.md)
 
 <h2> 6.3 Http API Introduction </h2>
-Please refer to:  
+Please refer to:
 [https://github.com/tronprotocol/Documentation/blob/master/TRX_CN/Tron-http.md](https://github.com/tronprotocol/Documentation/blob/master/TRX_CN/Tron-http.md)
 
 # 7. TRC-10 Token Introduction
-TRON network support two types of token, one is TRC-20 token issued by smart contract, the other one is TRC-10 token issued by system contract.    
+TRON network support two types of token, one is TRC-20 token issued by smart contract, the other one is TRC-10 token issued by system contract.
 
 <h2> 7.1 How to Issue a TRC-10 Token </h2>
 Http Api:
@@ -868,57 +868,57 @@ demo: curl -X POST  http://127.0.0.1:8090/wallet/createassetissue -d '{
 "public_free_asset_net_limit":10000,
 "frozen_supply":{"frozen_amount":1, "frozen_days":2}
 }'
-Parameter owner_address: Owner address, default hexString  
-Parameter name: Token name, default hexString    
-Parameter abbr: Token name abbreviation, default hexString  
-Parameter total_supply: Token total supply    
+Parameter owner_address: Owner address, default hexString
+Parameter name: Token name, default hexString
+Parameter abbr: Token name abbreviation, default hexString
+Parameter total_supply: Token total supply
 Parameter trx_num: Define the price by the ratio of trx_num/num,
-Parameter num: Define the price by the ratio of trx_num/num   
+Parameter num: Define the price by the ratio of trx_num/num
 Parameter start_time: ICO start time
-Parameter end_time: ICO end time    
+Parameter end_time: ICO end time
 Parameter description: Token description, default hexString
-Parameter url: Token official website url, default hexString   
-Parameter free_asset_net_limit: Token free asset net limit   
-Parameter public_free_asset_net_limit: Token public free asset net limit    
-Parameter frozen_supply: Token frozen supply  
-Parameter permission_id: Optional, for multi-signature use    
+Parameter url: Token official website url, default hexString
+Parameter free_asset_net_limit: Token free asset net limit
+Parameter public_free_asset_net_limit: Token public free asset net limit
+Parameter frozen_supply: Token frozen supply
+Parameter permission_id: Optional, for multi-signature use
 Return: Transaction object
 Note: The unit of 'trx_num' is SUN
 ```
 
 <h2> 7.2 Participate TRC-10 Token </h2>
-Http Api:  
+Http Api:
 
 ```text
 wallet/participateassetissue
 Description: Participate a token
 demo: curl -X POST http://127.0.0.1:8090/wallet/participateassetissue -d '{
 "to_address": "41e552f6487585c2b58bc2c9bb4492bc1f17132cd0",
-"owner_address":"41e472f387585c2b58bc2c9bb4492bc1f17342cd1", 
-"amount":100, 
+"owner_address":"41e472f387585c2b58bc2c9bb4492bc1f17342cd1",
+"amount":100,
 "asset_name":"3230313271756265696a696e67"
 }'
-Parameter to_address: The issuer address of the token, default hexString    
-Parameter owner_address: The participant address, default hexString 
+Parameter to_address: The issuer address of the token, default hexString
+Parameter owner_address: The participant address, default hexString
 Parameter amount: Participate token amount
-Parameter asset_name: Token id, default hexString         
-Parameter permission_id: Optional, for multi-signature use          
+Parameter asset_name: Token id, default hexString
+Parameter permission_id: Optional, for multi-signature use
 Return: Transaction object
 Note: The unit of 'amount' is the smallest unit of the token
 ```
 
 <h2> 7.3 TRC-10 Token Transfer </h2>
-Http Api: 
+Http Api:
 
 ```text
 wallet/transferasset
 Description: Transfer token
 demo: curl -X POST  http://127.0.0.1:8090/wallet/transferasset -d '{"owner_address":"41d1e7a6bc354106cb410e65ff8b181c600ff14292", "to_address": "41e552f6487585c2b58bc2c9bb4492bc1f17132cd0", "asset_name": "31303030303031", "amount": 100}'
-Parameter owner_address: Owner address, default hexString    
-Parameter to_address: To address, default hexString    
-Parameter asset_name: Token id, default hexString   
-Parameter amount: Token transfer amount    
-Parameter permission_id: Optional, for multi-signature use         
+Parameter owner_address: Owner address, default hexString
+Parameter to_address: To address, default hexString
+Parameter asset_name: Token id, default hexString
+Parameter amount: Token transfer amount
+Parameter permission_id: Optional, for multi-signature use
 Return: Transaction object
 Note: The unit of 'amount' is the smallest unit of the token
 ```
@@ -926,17 +926,17 @@ Note: The unit of 'amount' is the smallest unit of the token
 # 8. Resource Model
 <h2> 8.1 Resource Model Introduction </h2>
 
-TRON network has 4 types of resources: Bandwidth, CPU, Storage and RAM. Benefit by TRON's exclusive RAM model, TRON's RAM resource is almost infinite.   
+TRON network has 4 types of resources: Bandwidth, CPU, Storage and RAM. Benefit by TRON's exclusive RAM model, TRON's RAM resource is almost infinite.
 
-TRON network imports two resource conceptions: Bandwidth points and Energy. Bandwidth Point represents Bandwidth, Energy represents CPU and Storage.  
+TRON network imports two resource conceptions: Bandwidth points and Energy. Bandwidth Point represents Bandwidth, Energy represents CPU and Storage.
 
-Note:   
-- Ordinary transaction only consumes Bandwidth points  
+Note:
+- Ordinary transaction only consumes Bandwidth points
 - Smart contract related transaction not only consumes Bandwidth points, but also Energy
 
 <h2> 8.2 Bandwidth Points </h2>
 
-The transaction information is stored and transmitted in the form of byte array, Bandwidth Points consumed = the number of bytes of the transaction * Bandwidth Points rate. Currently Bandwidth Points rate = 1  
+The transaction information is stored and transmitted in the form of byte array, Bandwidth Points consumed = the number of bytes of the transaction * Bandwidth Points rate. Currently Bandwidth Points rate = 1
 
 Such as if the number of bytes of a transaction is 200, so this transaction consumes 200 Bandwidth Points.
 
@@ -944,57 +944,57 @@ Note: Due to the change of the total amount of the frozen TRX in the network and
 
 <h2> 8.2.1 How to Get Bandwidth Points </h2>
 
-1.&nbsp;By Freezing TRX to get Bandwidth Points, Bandwidth Points = the amount of TRX self-frozen / the total amount of TRX frozen for Bandwidth Points in the network * 43_200_000_000  
+1.&nbsp;By Freezing TRX to get Bandwidth Points, Bandwidth Points = the amount of TRX self-frozen / the total amount of TRX frozen for Bandwidth Points in the network * 43_200_000_000
 
-2.&nbsp;Every account has a fixed amount of free Bandwidth Points(5000) every day  
+2.&nbsp;Every account has a fixed amount of free Bandwidth Points(5000) every day
 
-<h3> 8.2.2 Bandwith Points Consumption </h3>
+<h3> 8.2.2 Bandwidth Points Consumption </h3>
 
-Except for query operation, any transaction consumes Bandwidth points.  
+Except for query operation, any transaction consumes Bandwidth points.
 
-There's another situation: When you transfer(TRX or token) to an account that does not exist in the network, this operation will first create that account in the network and then do the transfer. It only consumes Bandwidth points for account creation, no extra Bandwidth points consumption for transfer.  
+There's another situation: When you transfer(TRX or token) to an account that does not exist in the network, this operation will first create that account in the network and then do the transfer. It only consumes Bandwidth points for account creation, no extra Bandwidth points consumption for transfer.
 
-Create a new account transaction, Bandwidth points consumption sequence:  
+Create a new account transaction, Bandwidth points consumption sequence:
 
-1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;  
-2.&nbsp;Burn 0.1 TRX;  
+1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;
+2.&nbsp;Burn 0.1 TRX;
 
-Token transfer transaction, Bandwidth points consumption sequence:  
+Token transfer transaction, Bandwidth points consumption sequence:
 
 1.&nbsp;依次验证 发行Token资产总的免费Bandwidth Points是否足够消耗，转账发起者的Token剩余免费Bandwidth Points是否足够消耗，
     Token发行者冻结TRX获取Bandwidth Points剩余量是否足够消耗。如果满足则扣除Token发行者的Bandwidth Points，任意一个不满足则进入下一步。
-2.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;  
-3.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 4;  
-4.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;  
+2.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;
+3.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 4;
+4.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;
 
-Ordinary transaction, Bandwidth points consumption sequence:   
+Ordinary transaction, Bandwidth points consumption sequence:
 
-1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;  
-2.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;  
-3.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;  
+1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;
+2.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;
+3.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;
 
 <h3> 8.2.3 Bandwidth Points Recovery </h3>
-Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0. For the specific formula:  
+Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0. For the specific formula:
 ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/bandwidthRestoreEqn.gif)
 
-Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0.  
+Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0.
 
 <h2> 8.3 Energy </h2>
-[5.3 Energy Introduction](#53-energy-introduction)  
+[5.3 Energy Introduction](#53-energy-introduction)
 
 <h2> 8.4 Resource Delegation </h2>
-In TRON network, an account can freeze TRX for Bandwidth or Energy for other accounts. The primary account owns the frozen TRX and TRON power, the recipient account owns the Bandwidth or Energy. Like ordinary freezing, resource delegation freezing is also at least 3 days.  
+In TRON network, an account can freeze TRX for Bandwidth or Energy for other accounts. The primary account owns the frozen TRX and TRON power, the recipient account owns the Bandwidth or Energy. Like ordinary freezing, resource delegation freezing is also at least 3 days.
 
-+ Example(Using wallet-cli)  
++ Example(Using wallet-cli)
 ```text
 freezeBalance frozen_balance frozen_duration [ResourceCode:0 BANDWIDTH,1 ENERGY] [receiverAddress]
 
-frozen_balance: the amount of TRX to freeze (unit SUN)  
+frozen_balance: the amount of TRX to freeze (unit SUN)
 frozen_duration: the freezing period (currently a fixed 3 days)
-ResourceCode: 0 for Bandwidth, 1 for Energy  
-receiverAddress: recipient account address 
+ResourceCode: 0 for Bandwidth, 1 for Energy
+receiverAddress: recipient account address
 ```
-  
+
 <h2> 8.5 Other Fees </h2>
 
 |Type|Fee|
@@ -1006,67 +1006,67 @@ receiverAddress: recipient account address
 
 # 9. DEX Introduction
 
-TRON network supports decentralized exchange(DEX) using Bancor protocol. DEX is composed of many exchange pairs.  
+TRON network supports decentralized exchange(DEX) using Bancor protocol. DEX is composed of many exchange pairs.
 
 <h2> 9.1 What is an Exchange Pair </h2>
-The term of 'Exchange Pair' describes a trade between one token with another, like A/B, A/TRX.  
+The term of 'Exchange Pair' describes a trade between one token with another, like A/B, A/TRX.
 
 <h2> 9.2 Exchange Pair Creation </h2>
-Any account can create an exchange pair, it burns 1024 TRX.    
+Any account can create an exchange pair, it burns 1024 TRX.
 
-Please refer to 'wallet/exchangecreate':  
-[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)  
+Please refer to 'wallet/exchangecreate':
+[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)
 
 <h2> 9.3 Exchange Pair Transaction </h2>
-Any account can trade in the DEX. The trade follows Bancor protocol.   
+Any account can trade in the DEX. The trade follows Bancor protocol.
 
-Please refer to 'wallet/exchangetransaction':  
-[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)  
+Please refer to 'wallet/exchangetransaction':
+[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)
 
 <h2> 9.4 Exchange Pair Injection </h2>
-The exchange pair creator can inject more tokens into the exchange pair. Injection can decrease the range of ratio fluctuation. If one token is injected, the other one will be injected automatically to keep the current ratio of the two tokens unchanged.  
+The exchange pair creator can inject more tokens into the exchange pair. Injection can decrease the range of ratio fluctuation. If one token is injected, the other one will be injected automatically to keep the current ratio of the two tokens unchanged.
 
-Please refer to 'wallet/exchangeinject':  
-[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)      
+Please refer to 'wallet/exchangeinject':
+[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)
 
 <h2> 9.5 Exchange Pair Withdrawal </h2>
-The exchange pair creator can withdraw tokens from the exchange pair. Withdrawal can increase the range of ratio fluctuation. If one token is withdrawn, the other one will be withdrawn automatically to keep the current ratio of the two tokens unchanged.   
+The exchange pair creator can withdraw tokens from the exchange pair. Withdrawal can increase the range of ratio fluctuation. If one token is withdrawn, the other one will be withdrawn automatically to keep the current ratio of the two tokens unchanged.
 
 Please refer to 'wallet/exchangewithdraw':
-[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)    
+[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)
 
 <h2> 9.6 Query </h2>
 
 <h3> 9.6.1 Transaction Query </h3>
-ListExchanges: Query the list of all the exchange pairs  
-GetPaginatedExchangeList: Query the list of all the exchange pairs by pagination  
-GetExchangeById: Query an exchange pair by exchange pair id  
+ListExchanges: Query the list of all the exchange pairs
+GetPaginatedExchangeList: Query the list of all the exchange pairs by pagination
+GetExchangeById: Query an exchange pair by exchange pair id
 
 Please refer to:
-[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)   
+[https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-http.md)
 
 <h3> 9.6.2 Price Calculation </h3>
-The token price is determined by the ratio of the balance of the two tokens.  
+The token price is determined by the ratio of the balance of the two tokens.
 
 <h3> 9.6.3 Calculate the Amount of Token You Can Get </h3>
-sellTokenQuant is the amount of the first_token you want to sell;  
+sellTokenQuant is the amount of the first_token you want to sell;
 buyTokenQuant is the amount of second_token you can get;
-supply = 1_000_000_000_000_000_000L;   
-supplyQuant = -supply * (1.0 - Math.pow(1.0 + (double) sellTokenQuant/（firstTokenBalance + sellTokenQuant, 0.0005));   
-buyTokenQuant = （long）balance * (Math.pow(1.0 + (double) supplyQuant / supply, 2000.0) - 1.0); 
+supply = 1_000_000_000_000_000_000L;
+supplyQuant = -supply * (1.0 - Math.pow(1.0 + (double) sellTokenQuant/（firstTokenBalance + sellTokenQuant, 0.0005));
+buyTokenQuant = （long）balance * (Math.pow(1.0 + (double) supplyQuant / supply, 2000.0) - 1.0);
 
 
 # 10. Multi-Signatures
-Please refer to:  
-[TRON Multi-signatures](Tron-multi-signatures.md)    
+Please refer to:
+[TRON Multi-signatures](Tron-multi-signatures.md)
 
-# 11. Shielded Transaction  
-Please refer to:  
-[TRON Shielded Transaction](Tron-shielded-transaction.md)   
+# 11. Shielded Transaction
+Please refer to:
+[TRON Shielded Transaction](Tron-shielded-transaction.md)
 
 # 12. Wallet Introduction
 <h2> 12.1 wallet-cli Introduction </h2>
-Please refer to:  
+Please refer to:
 [https://github.com/tronprotocol/wallet-cli/blob/master/README.md](https://github.com/tronprotocol/wallet-cli/blob/master/README.md)
 
 <h2> 12.2 Get Transaction ID </h2>
@@ -1077,21 +1077,21 @@ Hash.sha256(transaction.getRawData().toByteArray())
 <h2> 12.3 Get Block ID </h2>
 
 ```text
-private byte[] generateBlockId(long blockNum, byte[] blockHash) { 
-  byte[] numBytes = Longs.toByteArray(blockNum); 
-  byte[] hash = blockHash; 
-  System.arraycopy(numBytes, 0, hash, 0, 8); 
+private byte[] generateBlockId(long blockNum, byte[] blockHash) {
+  byte[] numBytes = Longs.toByteArray(blockNum);
+  byte[] hash = blockHash;
+  System.arraycopy(numBytes, 0, hash, 0, 8);
   return hash;
-  }
+ }
 ```
 <h2> 12.4 How to Build a Transaction Locally </h2>
-According to the defination of the transaction, you need to fill up all the fields of the transaction.  
+According to the defination of the transaction, you need to fill up all the fields of the transaction.
 
-You need to set refference block and expiration time information, so you need to connect to the Mainnet. We recommend to use the latest block on fullnode as the value of refference block, use the latest block time plus N minutes as the value of expiration time.  
+You need to set reference block and expiration time information, so you need to connect to the Mainnet. We recommend to use the latest block on fullnode as the value of reference block, use the latest block time plus N minutes as the value of expiration time.
 
-The network judgment condition is if (expiration > latest block time and expiration < latest block time + 24 hours) means the transaction is in period of validity. Otherwise, it will be a overdue transaction, will not be accepted by the Mainnet.  
+The network judgment condition is if (expiration > latest block time and expiration < latest block time + 24 hours) means the transaction is in period of validity. Otherwise, it will be an overdue transaction, will not be accepted by the Mainnet.
 
-Way to set refference block: set RefBlockHash the bytes from the 8 to 16(not included) of the hash of the latest block, set BlockBytes the bytes from 6 to 8(not included) of the height of the latest block.  
+Way to set reference block: set RefBlockHash the bytes from the 8 to 16(not included) of the hash of the latest block, set BlockBytes the bytes from 6 to 8(not included) of the height of the latest block.
 ```text
 public static Transaction setReference(Transaction transaction, Block newestBlock) {
      long blockHeight = newestBlock.getBlockHeader().getRawData().getNumber();
@@ -1104,12 +1104,12 @@ public static Transaction setReference(Transaction transaction, Block newestBloc
      return transaction.toBuilder().setRawData(rawData).build();
    }
 ```
-Way to set expiration time and transaction timestamp:  
+Way to set expiration time and transaction timestamp:
 ```text
 public static Transaction createTransaction(byte[] from, byte[] to, long amount) {
      Transaction.Builder transactionBuilder = Transaction.newBuilder();
      Block newestBlock = WalletClient.getBlock(-1);
- 
+
      Transaction.Contract.Builder contractBuilder = Transaction.Contract.newBuilder();
      Contract.TransferContract.Builder transferContractBuilder = Contract.TransferContract
          .newBuilder();
@@ -1135,7 +1135,7 @@ public static Transaction createTransaction(byte[] from, byte[] to, long amount)
 ```
 <h2> 12.5 Related Demo </h2>
 
-Build transaction locally, signature demo, please refer to:  
-[https://github.com/tronprotocol/wallet-cli/blob/master/src/main/java/org/tron/demo/TransactionSignDemo.java](https://github.com/tronprotocol/wallet-cli/blob/master/src/main/java/org/tron/demo/TransactionSignDemo.java)  
-nodejs demo, please refer to:  
-[https://github.com/tronprotocol/tron-demo/tree/master/demo/nodejs](https://github.com/tronprotocol/tron-demo/tree/master/demo/nodejs)  
+Build transaction locally, signature demo, please refer to:
+[https://github.com/tronprotocol/wallet-cli/blob/master/src/main/java/org/tron/demo/TransactionSignDemo.java](https://github.com/tronprotocol/wallet-cli/blob/master/src/main/java/org/tron/demo/TransactionSignDemo.java)
+nodejs demo, please refer to:
+[https://github.com/tronprotocol/tron-demo/tree/master/demo/nodejs](https://github.com/tronprotocol/tron-demo/tree/master/demo/nodejs)

--- a/docs/api/rpc.md
+++ b/docs/api/rpc.md
@@ -4,7 +4,7 @@
 [https://github.com/tronprotocol/protocol/blob/master/api/api.proto](https://github.com/tronprotocol/protocol/blob/master/api/api.proto)
 [https://github.com/tronprotocol/protocol/blob/master/core/Contract.proto](https://github.com/tronprotocol/protocol/blob/master/core/Contract.proto)
 
-> NOTE: SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode.
+> NOTE: SolidityNode is deprecated. Now a FullNode supports all RPCs of a SolidityNode.
 > New developers should deploy FullNode only.
 
 **1.&nbsp;Get account information**

--- a/docs/api/rpc.md
+++ b/docs/api/rpc.md
@@ -1,298 +1,300 @@
+# RPC List
 
-**For the specific definition of API, please refer to the following link:**   
+**For the specific definition of API, please refer to the following link:**
 [https://github.com/tronprotocol/protocol/blob/master/api/api.proto](https://github.com/tronprotocol/protocol/blob/master/api/api.proto)
 [https://github.com/tronprotocol/protocol/blob/master/core/Contract.proto](https://github.com/tronprotocol/protocol/blob/master/core/Contract.proto)
 
+> NOTE: SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode.
+> New developers should deploy FullNode only.
 
-**1.&nbsp;Get account information**  
+**1.&nbsp;Get account information**
 
-Interface statement:  
-rpc GetAccount (Account) returns (Account) {}   
-Nodes: Fullnode and SolidityNode  
+Interface statement:
+rpc GetAccount (Account) returns (Account) {}
+Nodes: Fullnode and SolidityNode
 
-**2.&nbsp;TRX transfer**  
+**2.&nbsp;TRX transfer**
 
-Interface statement:  
-rpc CreateTransaction (TransferContract) returns (Transaction) {}   
-Nodes: Fullnode  
-
-**3.&nbsp;Broadcast transaction**  
-
-Interface statement:  
-rpc BroadcastTransaction (Transaction) returns (Return) {}   
-Nodes: Fullnode  
-Description:    
-Transfer, vote, issuance of token, or participation in token offering. Sending signed transaction information to node, and broadcasting it to the entire network after witness verification.
-
-**4.&nbsp;Create an account**  
- 
-Interface statement:  
-rpc CreateAccount (AccountCreateContract) returns (Transaction) {}  
-Nodes: FullNode  
-
-**5.&nbsp;Account name update**  
-Interface statement:  
-rpc UpdateAccount (AccountUpdateContract) returns (Transaction) {}  
-Nodes: Fullnode   
-
-**6.&nbsp;Vote for super representative candidates**  
-Interface statement:  
-rpc VoteWitnessAccount (VoteWitnessContract) returns (Transaction) {}    
-Nodes: FullNode    
-
-**7.&nbsp;Issue a token**  
-Interface statement:  
-rpc CreateAssetIssue (AssetIssueContract) returns (Transaction) {}      
-Nodes: FullNode    
-
-**8.&nbsp;Query of list of super representative candidates**    
-Interface statement:  
-rpc ListWitnesses (EmptyMessage) returns (WitnessList) {}     
-Nodes: FullNode and SolidityNode    
-
-**9.&nbsp;Application for super representative**  
-Interface statement:  
-rpc CreateWitness (WitnessCreateContract) returns (Transaction) {}  
-Nodes: FullNode  
-Description:  
-To apply to become TRON’s Super Representative candidate.  
-
-**10.&nbsp;Information update of Super Representative candidates**  
-Interface statement:  
-rpc UpdateWitness (WitnessUpdateContract) returns (Transaction) {}      
-Nodes: FullNode  
-Description:  
-Update the website url of the SR.  
-
-**11.&nbsp;Token transfer**  
-Interface statement :  
-rpc TransferAsset (TransferAssetContract) returns (Transaction){}     
-Node: FullNode    
-
-**12.&nbsp;Participate a token**  
-Interface statement:    
-rpc ParticipateAssetIssue (ParticipateAssetIssueContract) returns (Transaction) {}      
-Nodes: FullNode  
-
-**13.&nbsp;Query the list of nodes connected to the ip of the api**  
-Interface statement:    
-rpc ListNodes (EmptyMessage) returns (NodeList) {}  
-Nodes: FullNode and SolidityNode   
-
-**14.&nbsp;Query the list of all issued tokens**  
-Interface statement:    
-rpc GetAssetIssueList (EmptyMessage) returns (AssetIssueList) {}    
-Nodes: FullNode and SolidityNode    
-
-**15.&nbsp;Query the token issued by a given account**  
-Interface statement:    
-rpc GetAssetIssueByAccount (Account) returns (AssetIssueList) {}   
-Nodes: FullNode and SolidityNode    
-
-**16.&nbsp;Query the token information by token name**  
-Interface statement:    
-rpc GetAssetIssueByName (BytesMessage) returns (AssetIssueContract) {}    
-Nodes: FullNode and Soliditynode    
-
-**17.&nbsp;Query the list of tokens by timestamp**    
-Interface statement:  
-rpc GetAssetIssueListByTimestamp (NumberMessage) returns (AssetIssueList){}     
-Nodes: SolidityNode    
-
-**18.&nbsp;Get current block information**  
-Interface statement:  
-rpc GetNowBlock (EmptyMessage) returns (Block) {}      
-Nodes: FullNode and SolidityNode    
-
-**19.&nbsp;Get a block by block height**  
-Interface statement:  
-rpc GetBlockByNum (NumberMessage) returns (Block) {}    
-Nodes: FullNode and SolidityNode  
-
-**20.&nbsp;Get the total number of transactions**  
-Interface statement:    
-rpc TotalTransaction (EmptyMessage) returns (NumberMessage) {}    
-Nodes: FullNode and SolidityNode      
-
-**21.&nbsp;Query the transaction by transaction id**  
-Interface statement:  
-rpc getTransactionById (BytesMessage) returns (Transaction) {}      
-Nodes: SolidityNode     
-
-**22.&nbsp;Query the transaction by timestamp**  
-Interface statement:  
-rpc getTransactionsByTimestamp (TimeMessage) returns (TransactionList) {}    
-Nodes: SolidityNode   
-
-**23.&nbsp;Query the transactions initiated by an account**  
-Interface statement:    
-rpc getTransactionsFromThis (Account) returns (TransactionList) {}   
-Nodes: SolidityNode      
-
-**24.&nbsp;Query the transactions received by an account**  
-Interface statement:  
-rpc getTransactionsToThis (Account) returns (NumberMessage) {}     
-Nodes: SolidityNode      
-
-**25.&nbsp;Freeze TRX**  
-Interface statement:  
-rpc FreezeBalance (FreezeBalanceContract) returns (Transaction) {}     
-Nodes: FullNode      
-
-**26.&nbsp;Unfreeze TRX**  
-Interface statement:    
-rpc UnfreezeBalance (UnfreezeBalanceContract) returns (Transaction) {}    
-Nodes: FullNode   
-
-**27.&nbsp;Block producing reward redemption**  
-Interface statement:  
-rpc WithdrawBalance (WithdrawBalanceContract) returns (Transaction) {}   
-Nodes: FullNode  
-
-**28.&nbsp;Unfreeze token balance**  
-Interface statement:    
-rpc UnfreezeAsset (UnfreezeAssetContract) returns (Transaction) {}      
-Nodes: FullNode    
-
-**29.&nbsp;Query the next maintenance time**  
-Interface statement:      
-rpc GetNextMaintenanceTime (EmptyMessage) returns (NumberMessage) {}      
-Nodes: FullNode    
-
-**30.&nbsp;Query the transaction fee & block information**    
-Interface statement:    
-rpc GetTransactionInfoById (BytesMessage) returns (TransactionInfo) {}     
-Nodes: SolidityNode    
- 
-**31.&nbsp;Query block information by block id**    
-Interface statement:      
-rpc GetBlockById (BytesMessage) returns (Block) {}      
-Nodes: FullNode    
-
-**32.&nbsp;Update token information**    
-Interface statement:      
-rpc UpdateAsset (UpdateAssetContract) returns (Transaction) {}     
-Nodes: Fullnode      
-Description:     
-Token update can only be initiated by the token issuer to update token description, url, maximum bandwidth consumption by each account and total bandwidth consumption.    
-
-**33.&nbsp;Query the list of all the tokens by pagination**  
-Interface statement:    
-rpc GetPaginatedAssetIssueList (PaginatedMessage) returns (AssetIssueList) {}    
-Nodes: FullNode and SolidityNode    
-
-**34.&nbsp;To sign a transaction**    
-Interface statement:      
-rpc GetTransactionSign (TransactionSign) returns (Transaction) {}    
-Nodes: FullNode    
- 
-**35.&nbsp;Address and private key creation**    
-Interface statement:      
-rpc CreateAdresss (BytesMessage) returns (BytesMessage) {}  
+Interface statement:
+rpc CreateTransaction (TransferContract) returns (Transaction) {}
 Nodes: Fullnode
 
-**36.&nbsp;TRX easy transfer**  
-Interface statement:      
-rpc EasyTransfer (EasyTransferMessage) returns (EasyTransferResponse) {}    
-Nodes: FullNode  
+**3.&nbsp;Broadcast transaction**
 
-**37.&nbsp;Deploy a smart contract**    
-Interface statement:     
-rpc DeployContract (CreateSmartContract) returns (TransactionExtention) {}    
-Nodes: FullNode and SolidityNode  
+Interface statement:
+rpc BroadcastTransaction (Transaction) returns (Return) {}
+Nodes: Fullnode
+Description:
+Transfer, vote, issuance of token, or participation in token offering. Sending signed transaction information to node, and broadcasting it to the entire network after witness verification.
 
-**38.&nbsp;Trigger a smart contract**    
-Interface statement:    
-rpc TriggerContract (TriggerSmartContract) returns (TransactionExtention) {}    
-Nodes: FullNode   
+**4.&nbsp;Create an account**
 
-**39.&nbsp;Create a shielded transaction**      
-Interface statement:    
-rpc CreateShieldedTransaction (PrivateParameters) returns (TransactionExtention) {}  
-Nodes: FullNode  
+Interface statement:
+rpc CreateAccount (AccountCreateContract) returns (Transaction) {}
+Nodes: FullNode
 
-**40.&nbsp;Get a Merkle tree information of a note**      
-Interface statement:    
+**5.&nbsp;Account name update**
+Interface statement:
+rpc UpdateAccount (AccountUpdateContract) returns (Transaction) {}
+Nodes: Fullnode
+
+**6.&nbsp;Vote for super representative candidates**
+Interface statement:
+rpc VoteWitnessAccount (VoteWitnessContract) returns (Transaction) {}
+Nodes: FullNode
+
+**7.&nbsp;Issue a token**
+Interface statement:
+rpc CreateAssetIssue (AssetIssueContract) returns (Transaction) {}
+Nodes: FullNode
+
+**8.&nbsp;Query of list of super representative candidates**
+Interface statement:
+rpc ListWitnesses (EmptyMessage) returns (WitnessList) {}
+Nodes: FullNode and SolidityNode
+
+**9.&nbsp;Application for super representative**
+Interface statement:
+rpc CreateWitness (WitnessCreateContract) returns (Transaction) {}
+Nodes: FullNode
+Description:
+To apply to become TRON’s Super Representative candidate.
+
+**10.&nbsp;Information update of Super Representative candidates**
+Interface statement:
+rpc UpdateWitness (WitnessUpdateContract) returns (Transaction) {}
+Nodes: FullNode
+Description:
+Update the website url of the SR.
+
+**11.&nbsp;Token transfer**
+Interface statement :
+rpc TransferAsset (TransferAssetContract) returns (Transaction){}
+Node: FullNode
+
+**12.&nbsp;Participate a token**
+Interface statement:
+rpc ParticipateAssetIssue (ParticipateAssetIssueContract) returns (Transaction) {}
+Nodes: FullNode
+
+**13.&nbsp;Query the list of nodes connected to the ip of the api**
+Interface statement:
+rpc ListNodes (EmptyMessage) returns (NodeList) {}
+Nodes: FullNode and SolidityNode
+
+**14.&nbsp;Query the list of all issued tokens**
+Interface statement:
+rpc GetAssetIssueList (EmptyMessage) returns (AssetIssueList) {}
+Nodes: FullNode and SolidityNode
+
+**15.&nbsp;Query the token issued by a given account**
+Interface statement:
+rpc GetAssetIssueByAccount (Account) returns (AssetIssueList) {}
+Nodes: FullNode and SolidityNode
+
+**16.&nbsp;Query the token information by token name**
+Interface statement:
+rpc GetAssetIssueByName (BytesMessage) returns (AssetIssueContract) {}
+Nodes: FullNode and Soliditynode
+
+**17.&nbsp;Query the list of tokens by timestamp**
+Interface statement:
+rpc GetAssetIssueListByTimestamp (NumberMessage) returns (AssetIssueList){}
+Nodes: SolidityNode
+
+**18.&nbsp;Get current block information**
+Interface statement:
+rpc GetNowBlock (EmptyMessage) returns (Block) {}
+Nodes: FullNode and SolidityNode
+
+**19.&nbsp;Get a block by block height**
+Interface statement:
+rpc GetBlockByNum (NumberMessage) returns (Block) {}
+Nodes: FullNode and SolidityNode
+
+**20.&nbsp;Get the total number of transactions**
+Interface statement:
+rpc TotalTransaction (EmptyMessage) returns (NumberMessage) {}
+Nodes: FullNode and SolidityNode
+
+**21.&nbsp;Query the transaction by transaction id**
+Interface statement:
+rpc getTransactionById (BytesMessage) returns (Transaction) {}
+Nodes: SolidityNode
+
+**22.&nbsp;Query the transaction by timestamp**
+Interface statement:
+rpc getTransactionsByTimestamp (TimeMessage) returns (TransactionList) {}
+Nodes: SolidityNode
+
+**23.&nbsp;Query the transactions initiated by an account**
+Interface statement:
+rpc getTransactionsFromThis (Account) returns (TransactionList) {}
+Nodes: SolidityNode
+
+**24.&nbsp;Query the transactions received by an account**
+Interface statement:
+rpc getTransactionsToThis (Account) returns (NumberMessage) {}
+Nodes: SolidityNode
+
+**25.&nbsp;Freeze TRX**
+Interface statement:
+rpc FreezeBalance (FreezeBalanceContract) returns (Transaction) {}
+Nodes: FullNode
+
+**26.&nbsp;Unfreeze TRX**
+Interface statement:
+rpc UnfreezeBalance (UnfreezeBalanceContract) returns (Transaction) {}
+Nodes: FullNode
+
+**27.&nbsp;Block producing reward redemption**
+Interface statement:
+rpc WithdrawBalance (WithdrawBalanceContract) returns (Transaction) {}
+Nodes: FullNode
+
+**28.&nbsp;Unfreeze token balance**
+Interface statement:
+rpc UnfreezeAsset (UnfreezeAssetContract) returns (Transaction) {}
+Nodes: FullNode
+
+**29.&nbsp;Query the next maintenance time**
+Interface statement:
+rpc GetNextMaintenanceTime (EmptyMessage) returns (NumberMessage) {}
+Nodes: FullNode
+
+**30.&nbsp;Query the transaction fee & block information**
+Interface statement:
+rpc GetTransactionInfoById (BytesMessage) returns (TransactionInfo) {}
+Nodes: SolidityNode
+
+**31.&nbsp;Query block information by block id**
+Interface statement:
+rpc GetBlockById (BytesMessage) returns (Block) {}
+Nodes: FullNode
+
+**32.&nbsp;Update token information**
+Interface statement:
+rpc UpdateAsset (UpdateAssetContract) returns (Transaction) {}
+Nodes: Fullnode
+Description:
+Token update can only be initiated by the token issuer to update token description, url, maximum bandwidth consumption by each account and total bandwidth consumption.
+
+**33.&nbsp;Query the list of all the tokens by pagination**
+Interface statement:
+rpc GetPaginatedAssetIssueList (PaginatedMessage) returns (AssetIssueList) {}
+Nodes: FullNode and SolidityNode
+
+**34.&nbsp;To sign a transaction**
+Interface statement:
+rpc GetTransactionSign (TransactionSign) returns (Transaction) {}
+Nodes: FullNode
+
+**35.&nbsp;Address and private key creation**
+Interface statement:
+rpc CreateAdresss (BytesMessage) returns (BytesMessage) {}
+Nodes: Fullnode
+
+**36.&nbsp;TRX easy transfer**
+Interface statement:
+rpc EasyTransfer (EasyTransferMessage) returns (EasyTransferResponse) {}
+Nodes: FullNode
+
+**37.&nbsp;Deploy a smart contract**
+Interface statement:
+rpc DeployContract (CreateSmartContract) returns (TransactionExtention) {}
+Nodes: FullNode and SolidityNode
+
+**38.&nbsp;Trigger a smart contract**
+Interface statement:
+rpc TriggerContract (TriggerSmartContract) returns (TransactionExtention) {}
+Nodes: FullNode
+
+**39.&nbsp;Create a shielded transaction**
+Interface statement:
+rpc CreateShieldedTransaction (PrivateParameters) returns (TransactionExtention) {}
+Nodes: FullNode
+
+**40.&nbsp;Get a Merkle tree information of a note**
+Interface statement:
 rpc GetMerkleTreeVoucherInfo (OutputPointInfo) returns (IncrementalMerkleVoucherInfo) {}
-Nodes: FullNode  
+Nodes: FullNode
 
-**41.&nbsp;Scan note by ivk**     
-Interface statement:    
+**41.&nbsp;Scan note by ivk**
+Interface statement:
 rpc ScanNoteByIvk (IvkDecryptParameters) returns (DecryptNotes) {};
-Nodes: FullNode  
+Nodes: FullNode
 
-**42.&nbsp;Scan note by ovk**     
-Interface statement:    
+**42.&nbsp;Scan note by ovk**
+Interface statement:
 rpc ScanNoteByOvk (OvkDecryptParameters) returns (DecryptNotes) {};
-Nodes: FullNode  
+Nodes: FullNode
 
-**43.&nbsp;Get spending key**    
-Interface statement:    
+**43.&nbsp;Get spending key**
+Interface statement:
 rpc GetSpendingKey (EmptyMessage) returns (BytesMessage) {}
-Nodes: FullNode  
+Nodes: FullNode
 
-**44.&nbsp;Get expanded spending key**    
-Interface statement:    
+**44.&nbsp;Get expanded spending key**
+Interface statement:
 rpc GetExpandedSpendingKey (BytesMessage) returns (ExpandedSpendingKeyMessage) {}
-Nodes: FullNode  
+Nodes: FullNode
 
-**45.&nbsp;Get ak from ask**    
-Interface statement:    
+**45.&nbsp;Get ak from ask**
+Interface statement:
 rpc GetAkFromAsk (BytesMessage) returns (BytesMessage) {}
-Nodes: FullNode  
+Nodes: FullNode
 
-**46.&nbsp;Get nk from nsk**    
-Interface statement:    
+**46.&nbsp;Get nk from nsk**
+Interface statement:
 rpc GetNkFromNsk (BytesMessage) returns (BytesMessage) {}
-Nodes: FullNode  
+Nodes: FullNode
 
-**47.&nbsp;Get incoming viewing key**      
-Interface statement:    
+**47.&nbsp;Get incoming viewing key**
+Interface statement:
 rpc GetIncomingViewingKey (ViewingKeyMessage) returns (IncomingViewingKeyMessage) {}
-Nodes: FullNode  
- 
-**48.&nbsp;Get diversifier**      
-Interface statement:    
+Nodes: FullNode
+
+**48.&nbsp;Get diversifier**
+Interface statement:
 rpc GetDiversifier (EmptyMessage) returns (DiversifierMessage) {}
-Nodes: FullNode  
+Nodes: FullNode
 
-**49.&nbsp;Get zen payment address**      
-Interface statement:    
+**49.&nbsp;Get zen payment address**
+Interface statement:
 rpc GetZenPaymentAddress (IncomingViewingKeyDiversifierMessage) returns (PaymentAddressMessage) {}
-Nodes: FullNode  
+Nodes: FullNode
 
-**50.&nbsp;Get rcm**      
-Interface statement:    
+**50.&nbsp;Get rcm**
+Interface statement:
 rpc GetRcm (EmptyMessage) returns (BytesMessage) {}
-Nodes: FullNode   
+Nodes: FullNode
 
-**51.&nbsp;Get a note status of is spent or not**      
-Interface statement:    
+**51.&nbsp;Get a note status of is spent or not**
+Interface statement:
 rpc IsSpend (NoteParameters) returns (SpendResult) {}
-Nodes: FullNode   
+Nodes: FullNode
 
-**52.&nbsp;Create a shielded transaction without using ask**      
-Interface statement:    
+**52.&nbsp;Create a shielded transaction without using ask**
+Interface statement:
 rpc CreateShieldedTransactionWithoutSpendAuthSig (PrivateParametersWithoutAsk) returns (TransactionExtention) {};
-Nodes: FullNode  
+Nodes: FullNode
 
-**53.&nbsp;Create a shielded transaction hash**      
-Interface statement:    
+**53.&nbsp;Create a shielded transaction hash**
+Interface statement:
 rpc GetShieldTransactionHash (Transaction) returns (BytesMessage) {};
-Nodes: FullNode  
+Nodes: FullNode
 
-**54.&nbsp;Create a signature for a shielded transaction**      
-Interface statement:    
+**54.&nbsp;Create a signature for a shielded transaction**
+Interface statement:
 rpc CreateSpendAuthSig (SpendAuthSigParameters) returns (BytesMessage) {};
-Nodes: FullNode  
+Nodes: FullNode
 
-**56.&nbsp;Create a shield nullifier**      
-Interface statement:    
+**56.&nbsp;Create a shield nullifier**
+Interface statement:
 rpc CreateShieldNullifier (NfParameters) returns (BytesMessage) {};
-Nodes: FullNode  
+Nodes: FullNode
 
-**57.&nbsp;Get new shielded address**    
-Interface statement:    
+**57.&nbsp;Get new shielded address**
+Interface statement:
 rpc GetNewShieldedAddress (EmptyMessage) returns (ShieldedAddressInfo){}
-Nodes: FullNode  
-
+Nodes: FullNode

--- a/docs/architecture/network.md
+++ b/docs/architecture/network.md
@@ -29,7 +29,7 @@ CPU: > 64 cores RAM: > 64G, Bandwidth: > 500M, Disk: > 20T
 
 SolidityNode only synchronize solidified blocks data from the fullNode it specifies, It also provie api service.
 
-> NOTE: SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode.
+> NOTE: SolidityNode is deprecated. Now a FullNode supports all RPCs of a SolidityNode.
 > New developers should deploy FullNode only.
 
 Recommended Hardware Configuration:

--- a/docs/architecture/network.md
+++ b/docs/architecture/network.md
@@ -9,129 +9,129 @@ TRON network uses Peer-to-Peer(P2P) network instructure, all nodes status equal.
 
 Super Representative(abbr: SR) is the block producer in TRON network, there are 27 SR. They verify the transactions and write the transactions into the blocks, they take turns to produce blocks. The super Representatives' information is public to everyone in TRON network. The best way to browse is using [tronscan](https://tronscan.org/#/sr/representatives).
 
-Recommended Hardware Configuration:  
-minimum requirement:  
-CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T  
-Recommended requirement:  
+Recommended Hardware Configuration:
+minimum requirement:
+CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T
+Recommended requirement:
 CPU: > 64 cores RAM: > 64G, Bandwidth: > 500M, Disk: > 20T
 
-<h3>FullNode</h3> 
+<h3>FullNode</h3>
 
 FullNode has the complete block chain data, can update data in real time. It can broadcast the transactions and provide api service.
 
-Recommended Hardware Configuration:  
-minimum requirement:     
-CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T   
-Recommended requirement:  
+Recommended Hardware Configuration:
+minimum requirement:
+CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T
+Recommended requirement:
 CPU: > 64 cores RAM: > 64G, Bandwidth: > 500M, Disk: > 20T
 
 <h3>SolidityNode</h3>
 
-SolidityNode only synchronize solidified blocks data from the fullNode it specifies, It also provie api service.  
+SolidityNode only synchronize solidified blocks data from the fullNode it specifies, It also provie api service.
 
-Recommended Hardware Configuration:  
-minimum requirement:    
-CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T   
-Recommended requirement:  
+> NOTE: SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode.
+> New developers should deploy FullNode only.
+
+Recommended Hardware Configuration:
+minimum requirement:
+CPU: 16 cores, RAM: 32G, Bandwidth: 100M, Disk: 1T
+Recommended requirement:
 CPU: > 64 cores RAM: > 64G, Bandwidth: > 500M, Disk: > 20T
 
 
 ## MainNet, TestNet, PrivateNet
 
-MainNet, TestNet, PrivateNet all use the same code, only the node start configuration varies.  
+MainNet, TestNet, PrivateNet all use the same code, only the node start configuration varies.
 
 <h3>1. MainNet </h3>
 
-[MainNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/main_net_config.conf)  
+[MainNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/main_net_config.conf)
 
 <h3>2. TestNet </h3>
 
-[TestNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/test_net_config.conf)  
+[TestNet configuration](https://github.com/tronprotocol/tron-deployment/blob/master/test_net_config.conf)
 
 <h3>3. PrivateNet </h3>
 
 <h4>3.1 Preconditions </h4>
 
-- at least two accounts [generate an account](https://tronscan.org/#/wallet/new)  
-- at least deploy one SuperNode to produce blocks  
-- deploy serval FullNodes to synchronize blocks and broadcast transactions  
-- SuperNode and FullNode comprise the private network  
+- at least two accounts [generate an account](https://tronscan.org/#/wallet/new)
+- at least deploy one SuperNode to produce blocks
+- deploy serval FullNodes to synchronize blocks and broadcast transactions
+- SuperNode and FullNode comprise the private network
 
 <h5>3.2 Deployment </h5>
 
 <h6>3.2.1 Step 1: SuperNode Deployment </h6>
 
- 1.&nbsp;download private_net_config.conf  
+ 1.&nbsp;download private_net_config.conf
 
 ```text
 wget https://github.com/tronprotocol/tron-deployment/blob/master/private_net_config.conf
 ```
- 2.&nbsp;add your private key in localwitness  
- 3.&nbsp;set genesis.block.witnesses as the private key's corresponding address  
- 4.&nbsp;set p2p.version, any positive integer but 11111  
- 5.&nbsp;set the first SR needSyncCheck = false, others can be set true  
- 6.&nbsp;set node.discovery.enable = true  
- 7.&nbsp;run the script  
+ 2.&nbsp;add your private key in localwitness
+ 3.&nbsp;set genesis.block.witnesses as the private key's corresponding address
+ 4.&nbsp;set p2p.version, any positive integer but 11111
+ 5.&nbsp;set the first SR needSyncCheck = false, others can be set true
+ 6.&nbsp;set node.discovery.enable = true
+ 7.&nbsp;run the script
 
 ```text
 nohup java -Xmx6g -XX:+HeapDumpOnOutOfMemoryError -jar FullNode.jar  --witness  -c private_net_config.conf
 
-command line parameters introduction:  
---witness: start witness function, i.e.: --witness  
---log-config: specify the log configuration file path, i.e.: --log-config logback.xml  
--c: specify the configuration file path, i.e.: -c config.conf 
+command line parameters introduction:
+--witness: start witness function, i.e.: --witness
+--log-config: specify the log configuration file path, i.e.: --log-config logback.xml
+-c: specify the configuration file path, i.e.: -c config.conf
 ```
- 
- The usage of the log file:  
- You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:  
+
+ The usage of the log file:
+ You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:
  <logger name="net" level="WARN"/>
- The parameters in configuration file that need to modify:  
- localwitness:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/localwitness.jpg)  
- witnesses:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/witness.png)  
- version:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)  
- enable:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)  
+ The parameters in configuration file that need to modify:
+ localwitness:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/localwitness.jpg)
+ witnesses:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/witness.png)
+ version:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)
+ enable:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)
 
 
 <h6>3.2.2 Step 2: FullNode Deployment </h6>
- 1.&nbsp;Download private_net_config.conf  
+ 1.&nbsp;Download private_net_config.conf
 
 ```text
-wget https://github.com/tronprotocol/tron-deployment/blob/master/private_net_config.conf 
+wget https://github.com/tronprotocol/tron-deployment/blob/master/private_net_config.conf
 ```
- 2.&nbsp;set seed.node ip.list with SR's ip and port  
- 3.&nbsp;set p2p.version the same as SuperNode's p2p.version   
- 4.&nbsp;set genesis.block the same as genesis.block  
- 5.&nbsp;set needSyncCheck true   
- 6.&nbsp;set node.discovery.enable true   
- 7.&nbsp;run the script  
+ 2.&nbsp;set seed.node ip.list with SR's ip and port
+ 3.&nbsp;set p2p.version the same as SuperNode's p2p.version
+ 4.&nbsp;set genesis.block the same as genesis.block
+ 5.&nbsp;set needSyncCheck true
+ 6.&nbsp;set node.discovery.enable true
+ 7.&nbsp;run the script
 
 ```text
  nohup java -Xmx6g -XX:+HeapDumpOnOutOfMemoryError -jar FullNode.jar  --witness  -c private_net_config.conf
 
- command lines parameters  
- --witness: start witness function，i.e.: --witness  
- --log-config: specify the log configuration file path, i.e.: --log-config logback.xml  
+ command lines parameters
+ --witness: start witness function，i.e.: --witness
+ --log-config: specify the log configuration file path, i.e.: --log-config logback.xml
  -c: specify the configuration file path, i.e.: -c config.conf
 ```
 
- The usage of the log file:  
- You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:  
+ The usage of the log file:
+ You can change the level of the module to control the log output. The default level of each module is INFO, for example: only print the message with the level higher than warn:
  <logger name="net" level="WARN"/>
- The parameters in configuration file that need to modify:    
- ip.list:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/ip_list.png)  
- p2p.version:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)  
- genesis.block:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/genesis_block.png)  
- needSyncCheck:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/need_sync_check.png)  
- node.discovery.enable:  
- ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)  
- 
-
-
+ The parameters in configuration file that need to modify:
+ ip.list:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/ip_list.png)
+ p2p.version:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/p2p_version.png)
+ genesis.block:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/genesis_block.png)
+ needSyncCheck:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/need_sync_check.png)
+ node.discovery.enable:
+ ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/discovery_enable.png)

--- a/docs/developers/deployment.md
+++ b/docs/developers/deployment.md
@@ -1,5 +1,11 @@
+# Deployment
+
 ## Premise
 Create separate directories for fullnode and soliditynode
+
+> NOTE: SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode.
+> New developers should deploy FullNode only.
+
 ```text
 /deploy/fullnode
 /deploy/soliditynode
@@ -8,8 +14,8 @@ Create separate directories for fullnode and soliditynode
 Create two folders for fullnode and soliditynode.
 
 Clone the latest master branch of [https://github.com/tronprotocol/java-tron](https://github.com/tronprotocol/java-tron) and extract it to
-```text      
-/deploy/java-tron 
+```text
+/deploy/java-tron
 ```
 
 Make sure you have the proper dependencies.
@@ -22,21 +28,21 @@ Make sure you have the proper dependencies.
 
 ## Deployment Guide
 
-1.&nbsp;Build the java-tron project  
+1.&nbsp;Build the java-tron project
 ```text
-cd /deploy/java-tron 
+cd /deploy/java-tron
 ./gradlew build
 ```
 
 2.&nbsp;Copy the FullNode.jar and SolidityNode.jar along with configuration files into the respective directories
 ```text
-download your needed configuration file from https://github.com/tronprotocol/TronDeployment.  
+download your needed configuration file from https://github.com/tronprotocol/TronDeployment.
 
-main_net_config.conf is the configuration for MainNet, and test_net_config.conf is the configuration for TestNet.  
+main_net_config.conf is the configuration for MainNet, and test_net_config.conf is the configuration for TestNet.
 
-please rename the configuration file to `config.conf` and use this config.conf to start FullNode and SoliditNode.  
+please rename the configuration file to `config.conf` and use this config.conf to start FullNode and SoliditNode.
 
-cp build/libs/FullNode.jar ../fullnode  
+cp build/libs/FullNode.jar ../fullnode
 
 cp build/libs/SolidityNode.jar ../soliditynode
 ```
@@ -46,7 +52,7 @@ cp build/libs/SolidityNode.jar ../soliditynode
 java -jar FullNode.jar -c config.conf // make sure that your config.conf is downloaded from https://github.com/tronprotocol/TronDeployment
 ```
 
-4.&nbsp;Configure the SolidityNode configuration file  
+4.&nbsp;Configure the SolidityNode configuration file
 
 You need to edit `config.conf` to connect to your local FullNode. Change  `trustNode` in `node` to local `127.0.0.1:50051`, which is the default rpc port. Set `listen.port` to any number within the range of 1024-65535. Please don't use any ports between 0-1024 since you'll most likely hit conflicts with other system services. Also change `rpc port` to `50052` or something to avoid conflicts. **Please forward the UDP port 18888 for FullNode.**
 ```text
@@ -56,7 +62,7 @@ rpc {
 ```
 
 5.&nbsp;You can now run your SolidityNode using the following command：
-```text        
+```text
 java -jar SolidityNode.jar -c config.conf //make sure that your config.conf is downloaded from https://github.com/tronprotocol/TronDeployment
 ```
 
@@ -69,14 +75,14 @@ java -jar FullNode.jar -p 650950B193DDDDB35B6E48912DD28F7AB0E7140C1BFDEFD493348F
 
 This is similar to running a private testnet, except that the IPs in the `config.conf` are officially declared by TRON.
 
-7.&nbsp;Running a Super Representative Node for private testnet  
+7.&nbsp;Running a Super Representative Node for private testnet
 
-You should modify the config.conf:   
+You should modify the config.conf:
 
 - Replace existing entry in genesis.block.witnesses with your address
 - Replace existing entry in seed.node ip.list with your ip list
 - The first Super Node start, needSyncCheck should be set false
-- Set p2pversion to 61 
+- Set p2pversion to 61
 
 ```text
 cd build/libs
@@ -118,9 +124,9 @@ while true; do
 done
 ```
 
-## FullNode and SolidityNode Fast Deployment 
+## FullNode and SolidityNode Fast Deployment
 
-Download fast deployment script, run the script according to different types of node.   
+Download fast deployment script, run the script according to different types of node.
 
 <h3>Scope of use</h3>
 
@@ -181,7 +187,7 @@ This script helps you download the code from https://github.com/tronprotocol/grp
 
 <h3> Pre-requests </h3>
 
-Please follow the guide on https://github.com/tronprotocol/grpc-gateway 
+Please follow the guide on https://github.com/tronprotocol/grpc-gateway
 Install Golang, Protoc, and set $GOPATH environment variable according to your requirement.
 
 <h3> Download and run script </h3>
@@ -193,7 +199,7 @@ wget https://raw.githubusercontent.com/tronprotocol/TronDeployment/master/deploy
 <h3> Parameter Illustration </h3>
 
 ```shell
-bash deploy_grpc_gateway.sh --rpchost [rpc host ip] --rpcport [rpc port number] --httpport [http port number] 
+bash deploy_grpc_gateway.sh --rpchost [rpc host ip] --rpcport [rpc port number] --httpport [http port number]
 
 --rpchost The fullnode or soliditynode IP where the grpc service is provided. Default value is "localhost".
 --rpcport The fullnode or soliditynode port number grpc service is consuming. Default value is 50051.
@@ -213,17 +219,17 @@ bash deploy_grpc_gateway.sh --rpchost 127.0.0.1 --rpcport 50052 --httpport 18891
 
 ## Event Subscribe plugin Deployment
 
-This is an implementation of Tron eventsubscribe model. 
+This is an implementation of Tron eventsubscribe model.
 
-* **api** module defines IPluginEventListener, a protocol between Java-tron and event plugin. 
+* **api** module defines IPluginEventListener, a protocol between Java-tron and event plugin.
 * **app** module is an example for loading plugin, developers could use it for debugging.
-* **kafkaplugin** module is the implementation for kafka, it implements IPluginEventListener, it receives events subscribed from Java-tron and relay events to kafka server. 
-* **mongodbplugin** mongodbplugin module is the implementation for mongodb. 
+* **kafkaplugin** module is the implementation for kafka, it implements IPluginEventListener, it receives events subscribed from Java-tron and relay events to kafka server.
+* **mongodbplugin** mongodbplugin module is the implementation for mongodb.
 
 <h3> Setup/Build </h3>
 
 1. Clone the repo `git clone https://github.com/tronprotocol/event-plugin.git`
-2. Go to eventplugin `cd event-plugin` 
+2. Go to eventplugin `cd event-plugin`
 3. run `./gradlew build`
 
 * This will produce one plugin zip, named `plugin-kafka-1.0.0.zip`, located in the `event-plugin/build/plugins/` directory.
@@ -280,11 +286,11 @@ event.subscribe = {
  * **dbconfig**: db configuration information for mongodb, if using kafka, delete this one; if using Mongodb, add like that dbname|username|password
  * **triggerName**: the trigger type, the value can't be modified.
  * **enable**: plugin can receive nothing if the value is false.
- * **topic**: the value is the kafka topic to receive events. Make sure it has been created and Kafka process is running  
+ * **topic**: the value is the kafka topic to receive events. Make sure it has been created and Kafka process is running
  * **filter**: filter condition for process trigger.
- **note**: if the server is not 127.0.0.1, pls set some properties in config/server.properties file  
-           remove comment and set listeners=PLAINTEXT://:9092  
-           remove comment and set advertised.listeners to PLAINTEXT://host_ip:9092 
+ **note**: if the server is not 127.0.0.1, pls set some properties in config/server.properties file
+           remove comment and set listeners=PLAINTEXT://:9092
+           remove comment and set advertised.listeners to PLAINTEXT://host_ip:9092
 
 <h3 id="kafka"> Install Kafka </h3>
 
@@ -297,7 +303,7 @@ brew install kafka
 ```
 cd /usr/local
 wget http://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz
-tar -xzvf kafka_2.10-0.10.2.2.tgz 
+tar -xzvf kafka_2.10-0.10.2.2.tgz
 mv kafka_2.10-0.10.2.2 kafka
 
 add "export PATH=$PATH:/usr/local/kafka/bin" to end of /etc/profile
@@ -319,12 +325,12 @@ zookeeper-server-start /usr/local/etc/kafka/zookeeper.properties & kafka-server-
 **On Linux**:
 ```
 zookeeper-server-start.sh /usr/local/kafka/config/zookeeper.properties &
-Sleep about 3 seconds 
+Sleep about 3 seconds
 kafka-server-start.sh /usr/local/kafka/config/server.properties &
 ```
 
 <h3> Create topics to receive events, the topic is defined in config.conf </h3>
- 
+
 **On Mac**:
 ```
 kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic block
@@ -363,7 +369,7 @@ kafka-console-consumer.sh --zookeeper localhost:2181 --topic contractevent
 
 * add --es to command line, for example:
 ```
- java -jar FullNode.jar -p privatekey -c config.conf --es 
+ java -jar FullNode.jar -p privatekey -c config.conf --es
 ```
 
 
@@ -387,10 +393,10 @@ filter = {
 
 <h3 id="mongo"> Download and install MongoDB </h3>
 
-** Suggested Configuration ** 
+** Suggested Configuration **
 
-- CPU/ RAM: 16Core / 32G  
-- DISK: 500G  
+- CPU/ RAM: 16Core / 32G
+- DISK: 500G
 - System: CentOS 64
 
 The version of MongoDB is **4.0.4**, below is the command:
@@ -461,10 +467,10 @@ Create data, log subfolder in mongodb directory,  and add their absolute path to
 
 ** Set database index to speedup query: **
 
-cd /{projectPath}   
+cd /{projectPath}
 sh insertIndex.sh
 
-## Event query service deployment  
+## Event query service deployment
 
 <h3>Download sourcecode</h3>
 
@@ -477,16 +483,16 @@ cd troneventquery
 
 - mvn package
 
-After the build command is executed successfully, troneventquery jar to release will be generated under troneventquery/target directory. 
+After the build command is executed successfully, troneventquery jar to release will be generated under troneventquery/target directory.
 
 Configuration of mongodb "config.conf" should be created for storing mongodb configuration, such as database name, username, password, and so on. We provided an example in sourcecode, which is " troneventquery/config.conf ". Replace with your specified configuration if needed.
 
-**Note**: 
+**Note**:
 
 Make sure the relative path of config.conf and troneventquery jar. The config.conf 's path is the parent of troneventquery jar.
 
- - mongo.host=IP 
- - mongo.port=27017 
+ - mongo.host=IP
+ - mongo.port=27017
  - mongo.dbname=eventlog
  - mongo.username=tron
  - mongo.password=123456

--- a/docs/developers/deployment.md
+++ b/docs/developers/deployment.md
@@ -3,7 +3,7 @@
 ## Premise
 Create separate directories for fullnode and soliditynode
 
-> NOTE: SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode.
+> NOTE: SolidityNode is deprecated. Now a FullNode supports all RPCs of a SolidityNode.
 > New developers should deploy FullNode only.
 
 ```text

--- a/docs/mechanism&algorithm/resource.md
+++ b/docs/mechanism&algorithm/resource.md
@@ -1,17 +1,17 @@
 
 ## Introduction
 
-TRON network has 4 types of resources: Bandwidth, CPU, Storage and RAM. Benefit by TRON's exclusive RAM model, TRON's RAM resource is almost infinite.   
+TRON network has 4 types of resources: Bandwidth, CPU, Storage and RAM. Benefit by TRON's exclusive RAM model, TRON's RAM resource is almost infinite.
 
-TRON network imports two resource conceptions: Bandwidth points and Energy. Bandwidth Point represents Bandwidth, Energy represents CPU and Storage.  
+TRON network imports two resource conceptions: Bandwidth points and Energy. Bandwidth Point represents Bandwidth, Energy represents CPU and Storage.
 
-Note:   
-- Ordinary transaction only consumes Bandwidth points  
+Note:
+- Ordinary transaction only consumes Bandwidth points
 - Smart contract related transaction not only consumes Bandwidth points, but also Energy
 
-## Bandwidth Points 
+## Bandwidth Points
 
-The transaction information is stored and transmitted in the form of byte array, Bandwidth Points consumed = the number of bytes of the transaction * Bandwidth Points rate. Currently Bandwidth Points rate = 1  
+The transaction information is stored and transmitted in the form of byte array, Bandwidth Points consumed = the number of bytes of the transaction * Bandwidth Points rate. Currently Bandwidth Points rate = 1
 
 Such as if the number of bytes of a transaction is 200, so this transaction consumes 200 Bandwidth Points.
 
@@ -19,64 +19,64 @@ Note: Due to the change of the total amount of the frozen TRX in the network and
 
 <h3> 1. How to Get Bandwidth Points </h3>
 
-1.&nbsp;By Freezing TRX to get Bandwidth Points, Bandwidth Points = the amount of TRX self-frozen / the total amount of TRX frozen for Bandwidth Points in the network * 43_200_000_000  
+1.&nbsp;By Freezing TRX to get Bandwidth Points, Bandwidth Points = the amount of TRX self-frozen / the total amount of TRX frozen for Bandwidth Points in the network * 43_200_000_000
 
-2.&nbsp;Every account has a fixed amount of free Bandwidth Points(5000) every day  
+2.&nbsp;Every account has a fixed amount of free Bandwidth Points(5000) every day
 
-<h3> 2. Bandwith Points Consumption </h3>
+<h3> 2. Bandwidth Points Consumption </h3>
 
-Except for query operation, any transaction consumes Bandwidth points.  
+Except for query operation, any transaction consumes Bandwidth points.
 
-There's another situation: When you transfer(TRX or token) to an account that does not exist in the network, this operation will first create that account in the network and then do the transfer. It only consumes Bandwidth points for account creation, no extra Bandwidth points consumption for transfer.  
+There's another situation: When you transfer(TRX or token) to an account that does not exist in the network, this operation will first create that account in the network and then do the transfer. It only consumes Bandwidth points for account creation, no extra Bandwidth points consumption for transfer.
 
-Create a new account transaction, Bandwidth points consumption sequence:  
+Create a new account transaction, Bandwidth points consumption sequence:
 
-1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;  
+1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;
 
-2.&nbsp;Burn 0.1 TRX;  
+2.&nbsp;Burn 0.1 TRX;
 
-Token transfer transaction, Bandwidth points consumption sequence:  
+Token transfer transaction, Bandwidth points consumption sequence:
 
-1.&nbsp;Firstly, check if the total free Bandwidth Points of the token issuer is enough, then check if the transfer Initiator‘s remaining token freeBandwidth Points is enough, finally check if the Bandwidth Points of token issuer obtained by freezing TRX is enough. Otherise, it will go to step 2;  
+1.&nbsp;Firstly, check if the total free Bandwidth Points of the token issuer is enough, then check if the transfer Initiator‘s remaining token freeBandwidth Points is enough, finally check if the Bandwidth Points of token issuer obtained by freezing TRX is enough. Otherise, it will go to step 2;
 
-2.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;  
+2.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;
 
-3.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 4;   
+3.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 4;
 
-4.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;  
+4.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;
 
-Ordinary transaction, Bandwidth points consumption sequence:   
+Ordinary transaction, Bandwidth points consumption sequence:
 
-1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;    
+1.&nbsp;Bandwidth points from freezing TRX. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 2;
 
-2.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;    
+2.&nbsp;Free Bandwidth points. If transaction initiator does not have enough Bandwidth Points of this type, it will go to step 3;
 
-3.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;    
+3.&nbsp;Bandwidth points from burning TRX, the rate = the number of bytes of the transaction * 10 SUN;
 
 
 <h3> 3. Bandwidth Points Recovery </h3>
-Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0. For the specific formula:  
+Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0. For the specific formula:
 ![image](https://raw.githubusercontent.com/tronprotocol/documentation-EN/master/imags/bandwidthRestoreEqn.gif)
 
-Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0.  
+Every 24 hours, the amount of the usage of Bandwidth points of an account will be reset to 0.
 
 ## Energy
 
-Each command of smart contract consume system resource while running, we use 'Energy' as the unit of the consumption of the resource.  
+Each command of smart contract consume system resource while running, we use 'Energy' as the unit of the consumption of the resource.
 
 <h3> 1. How to Get Energy </h3>
 
-Freeze TRX to get energy.  
+Freeze TRX to get energy.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 
 ```text
 freezeBalance frozen_balance frozen_duration [ResourceCode:0 BANDWIDTH,1 ENERGY]
 ```
 
-Freeze TRX to get energy, energy obtained = user's TRX frozen amount / total amount of frozen TRX in TRON * 50_000_000_000.  
+Freeze TRX to get energy, energy obtained = user's TRX frozen amount / total amount of frozen TRX in TRON * 50_000_000_000.
 
-Example:  
+Example:
 
 ```text
 If there are only two users, A freezes 2 TRX, B freezes 2 TRX
@@ -91,11 +91,11 @@ B: 20_000_000_000 and energy_limit is 20_000_000_000
 B: 10_000_000_000 and energy_limit is 10_000_000_000
 ```
 
-** Energy Recovery **  
+** Energy Recovery **
 
-The energy consumed will reduce to 0 smoothly within 24 hours.  
+The energy consumed will reduce to 0 smoothly within 24 hours.
 
-Example:  
+Example:
 
 ```text
 at one moment, A has used 72_000_000 Energy
@@ -113,61 +113,61 @@ one hour later, the energy consumption amount will be 72_000_000 - (72_000_000 *
 
 ***
 
-Set a rational fee limit can guarantee the smart contract execution. And if the execution of the contract cost great energy, it will not consume too much energy from the caller. Before you set fee limit, you need to know several conception:  
+Set a rational fee limit can guarantee the smart contract execution. And if the execution of the contract cost great energy, it will not consume too much energy from the caller. Before you set fee limit, you need to know several conception:
 
-1.&nbsp;The legal fee limit is a integer between 0 - 10^9, unit is SUN.  
+1.&nbsp;The legal fee limit is a integer between 0 - 10^9, unit is SUN.
 
-2.&nbsp;Different smart contracts consume different amount of energy due to their complexity. The same trigger in the same contract almost consumes the same amount fo energy[1]. When the contract is triggered, the commands will be excuted one by one and consume energy. If it reaches the fee limit, commands will fail to be excuted, and energy is not refundable.  
+2.&nbsp;Different smart contracts consume different amount of energy due to their complexity. The same trigger in the same contract almost consumes the same amount fo energy[1]. When the contract is triggered, the commands will be executed one by one and consume energy. If it reaches the fee limit, commands will fail to be executed, and energy is not refundable.
 
-3.&nbsp;Currently fee limit only refers to the energy converted to SUN that will be consumed from the caller[2]. The energy consumed by triggering contract also includes developer's share.  
+3.&nbsp;Currently fee limit only refers to the energy converted to SUN that will be consumed from the caller[2]. The energy consumed by triggering contract also includes developer's share.
 
-4.&nbsp;For a vicious contract, if it encounters execution timeout or bug crash, all it's energy will be consumed.  
+4.&nbsp;For a vicious contract, if it encounters execution timeout or bug crash, all it's energy will be consumed.
 
-5.&nbsp;Developer may undertake a proportion of energy consumption(like 90%). But if the developer's energy is not enough for consumption, the rest of the energy consumption will be undertaken by caller completely. Within the fee limit range, if the caller does not have enough energy, then it will burn equivalent amount of TRX [2].  
+5.&nbsp;Developer may undertake a proportion of energy consumption(like 90%). But if the developer's energy is not enough for consumption, the rest of the energy consumption will be undertaken by caller completely. Within the fee limit range, if the caller does not have enough energy, then it will burn equivalent amount of TRX [2].
 
-To encourage caller to trigger the contract, usually developer has enough energy.  
+To encourage caller to trigger the contract, usually developer has enough energy.
 
-** Example **  
+** Example **
 
-How to estimate the fee limit:  
+How to estimate the fee limit:
 
-Assume contract C's last execution consumes 18000 Energy, so estimate the energy consumption limit to be 20000 Energy[3]  
+Assume contract C's last execution consumes 18000 Energy, so estimate the energy consumption limit to be 20000 Energy[3]
 
-According to the frozen TRX amount and energy conversion, assume 1 TRX = 400 energy. 
+According to the frozen TRX amount and energy conversion, assume 1 TRX = 400 energy.
 
-When to burn TRX, 1 TRX = 10000 energy[4]  
+When to burn TRX, 1 TRX = 10000 energy[4]
 
-Assume developer undertake 90% energy consumption, and developer has enough energy.  
- 
-Then the way to estimate the fee limit is:   
+Assume developer undertake 90% energy consumption, and developer has enough energy.
 
-1). A = 20000 energy * (1 TRX / 400 energy) = 50 TRX = 50_000_000 SUN,  
-2). B = 20000 energy * (1 TRX / 10000 energy) = 2 TRX = 2_000_000 SUN,  
-3). Take the greater number of A and B, which is 50_000_000 SUN,  
-4). Developer undertakes 90% energy consumption, caller undertakes 10% energy consumption,  
+Then the way to estimate the fee limit is:
 
-So, the caller is suggested to set fee limit to 50_000_000 SUN * 10% = 5_000_000 SUN  
+1). A = 20000 energy * (1 TRX / 400 energy) = 50 TRX = 50_000_000 SUN,
+2). B = 20000 energy * (1 TRX / 10000 energy) = 2 TRX = 2_000_000 SUN,
+3). Take the greater number of A and B, which is 50_000_000 SUN,
+4). Developer undertakes 90% energy consumption, caller undertakes 10% energy consumption,
 
-Note:  
+So, the caller is suggested to set fee limit to 50_000_000 SUN * 10% = 5_000_000 SUN
 
-[1] The energy consumption of each execution may fluctuate slightly due to the situation of all the nodes.  
-[2] TRON may change this policy.  
-[3] The estimated energy consumption limit for the next execution should be greater than the last one.  
-[4] 1 TRX = 10^4 energy is a fixed number for burning TRX to get energy, TRON may change it in future.  
+Note:
+
+[1] The energy consumption of each execution may fluctuate slightly due to the situation of all the nodes.
+[2] TRON may change this policy.
+[3] The estimated energy consumption limit for the next execution should be greater than the last one.
+[4] 1 TRX = 10^4 energy is a fixed number for burning TRX to get energy, TRON may change it in future.
 
 <h3> 3. Energy Calculation (Developer Must Read)  </h3>
 
-1.&nbsp;In order to punish the vicious developer, for the abnormal contract, if the execution times out (more than 50ms) or quits due to bug (revert not included), the maximum available energy will be deducted. If the contract runs normally or revert, only the energy needed for the execution of the commands will be deducted.  
+1.&nbsp;In order to punish the vicious developer, for the abnormal contract, if the execution times out (more than 50ms) or quits due to bug (revert not included), the maximum available energy will be deducted. If the contract runs normally or revert, only the energy needed for the execution of the commands will be deducted.
 
-2.&nbsp;Developer can set the proportion of the energy consumption it undertakes during the execution, this proportion cna be changed later. If the developer's energy is not enough, it will consume the caller's energy.  
+2.&nbsp;Developer can set the proportion of the energy consumption it undertakes during the execution, this proportion cna be changed later. If the developer's energy is not enough, it will consume the caller's energy.
 
-3.&nbsp;Currently, the total energy available when trigger a contract is composed of caller fee limit and developer's share  
+3.&nbsp;Currently, the total energy available when trigger a contract is composed of caller fee limit and developer's share
 
-Note:  
-- If the developer is not sure about whether the contract is normal, do not set caller's energy consumption proportion to 0%, in case all developer's energy will be deducted due to vicious execution[1].  
-- We recommend to set caller's energy consumption proportion to 10% ~ 100%[2]. 
+Note:
+- If the developer is not sure about whether the contract is normal, do not set caller's energy consumption proportion to 0%, in case all developer's energy will be deducted due to vicious execution[1].
+- We recommend to set caller's energy consumption proportion to 10% ~ 100%[2].
 
-** Example 1 **   
+** Example 1 **
 
 A has an account with a balance of 90 TRX(90000000 SUN) and 10 TRX frozen for 100000 energy.
 
@@ -175,64 +175,64 @@ Smart contract C set the caller energy consumption proportion to 100% which mean
 
 A triggers C, the fee limit set is 30000000 (unit SUN, 30 TRX)
 
-So during this trigger the energy A can use is from two parts:  
-- A's energy by freezing TRX;  
-- The energy converted from the amount of TRX burning according to a fixed rate;  
+So during this trigger the energy A can use is from two parts:
+- A's energy by freezing TRX;
+- The energy converted from the amount of TRX burning according to a fixed rate;
 
-If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (30 - 10) TRX = 20 TRX available, so the energy it can keep consuming is 20 TRX / 100 SUN = 200000 energy.   
+If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (30 - 10) TRX = 20 TRX available, so the energy it can keep consuming is 20 TRX / 100 SUN = 200000 energy.
 
-Finally, in this call, the energy A can use is (100000 + 200000) = 300000 energy.  
+Finally, in this call, the energy A can use is (100000 + 200000) = 300000 energy.
 
-If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use. 
+If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use.
 
-If Assert-style error come out, it will consume the whole number of energy set for fee limit.  
+If Assert-style error come out, it will consume the whole number of energy set for fee limit.
 
-Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)  
+Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)
 
-** Example 2 **    
+** Example 2 **
 
-A has an account with a balance of 90 TRX(90000000 SUN) and 10 TRX frozen for 100000 energy.  
+A has an account with a balance of 90 TRX(90000000 SUN) and 10 TRX frozen for 100000 energy.
 
-Smart contract C set the caller energy consumption proportion to 40% which means the developer will pay for the rest 60% energy consumption.  
+Smart contract C set the caller energy consumption proportion to 40% which means the developer will pay for the rest 60% energy consumption.
 
-Developer D freezes 50 TRX to get 500000 energy.  
+Developer D freezes 50 TRX to get 500000 energy.
 
-A triggers C, the fee limit set is 200000000 (unit SUN, 200 TRX).  
+A triggers C, the fee limit set is 200000000 (unit SUN, 200 TRX).
 
-So during this trigger the energy A can use is from three parts:  
-- A's energy by freezing TRX -- X;  
-- The energy converted from the amount of TRX bruning according to a fixed rate -- Y;   
-If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (200 - 10) TRX = 190 TRX available, but A only has 90 TRX left, so the energy it can keep consuming is 90 TRX / 100 SUN = 900000 energy;  
-- D's energy by freezing TRX -- Z;  
+So during this trigger the energy A can use is from three parts:
+- A's energy by freezing TRX -- X;
+- The energy converted from the amount of TRX bruning according to a fixed rate -- Y;
+If fee limit is greater than the energy obtained from freezing TRX, then it will burn TRX to get energy. The fixed rate is: 1 Energy = 100 SUN, fee limit still has (200 - 10) TRX = 190 TRX available, but A only has 90 TRX left, so the energy it can keep consuming is 90 TRX / 100 SUN = 900000 energy;
+- D's energy by freezing TRX -- Z;
 
-There are two situation:  
-if (X + Y) / 40% >= Z / 60%, the energy A can use is X + Y + Z  
-if (X + Y) / 40% < Z / 60%, the energy A can use is (X + Y) / 40%  
+There are two situation:
+if (X + Y) / 40% >= Z / 60%, the energy A can use is X + Y + Z
+if (X + Y) / 40% < Z / 60%, the energy A can use is (X + Y) / 40%
 
-If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use.   
+If contract executes successfully without any exception, the energy needed for the execution will be deducted. Generally, it is far more less than the amount of energy this trigger can use.
 
-If Assert-style error comes out, it will consume the whole number of energy set for fee limit. Assert-style error introduction, refer to (https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)  
- 
-Note: when developer create a contract, do not set consume_user_resource_percent to 0, which means developer will undertake all the energy consumption. If Assert-style error comes out, it will consume all energy from the developer itsef.  
+If Assert-style error comes out, it will consume the whole number of energy set for fee limit. Assert-style error introduction, refer to (https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)
 
-Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)  
+Note: when developer create a contract, do not set consume_user_resource_percent to 0, which means developer will undertake all the energy consumption. If Assert-style error comes out, it will consume all energy from the developer itsef.
 
-To avoid unnecessary lost, 10 - 100 is recommended for consume_user_resource_percent.  
+Assert-style error introduction, refer to [https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md](https://github.com/tronprotocol/Documentation/blob/master/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3/%E8%99%9A%E6%8B%9F%E6%9C%BA/%E5%BC%82%E5%B8%B8%E5%A4%84%E7%90%86.md)
+
+To avoid unnecessary lost, 10 - 100 is recommended for consume_user_resource_percent.
 
 ## Resource Delegation
-In TRON network, an account can freeze TRX for Bandwidth or Energy for other accounts. The primary account owns the frozen TRX and TRON power, the recipient account owns the Bandwidth or Energy. Like ordinary freezing, resource delegation freezing is also at least 3 days.  
+In TRON network, an account can freeze TRX for Bandwidth or Energy for other accounts. The primary account owns the frozen TRX and TRON power, the recipient account owns the Bandwidth or Energy. Like ordinary freezing, resource delegation freezing is also at least 3 days.
 
-+ Example(Using wallet-cli)  
++ Example(Using wallet-cli)
 ```text
 freezeBalance frozen_balance frozen_duration [ResourceCode:0 BANDWIDTH,1 ENERGY] [receiverAddress]
 
-frozen_balance: the amount of TRX to freeze (unit SUN)  
+frozen_balance: the amount of TRX to freeze (unit SUN)
 frozen_duration: the freezing period (currently a fixed 3 days)
-ResourceCode: 0 for Bandwidth, 1 for Energy  
-receiverAddress: recipient account address 
+ResourceCode: 0 for Bandwidth, 1 for Energy
+receiverAddress: recipient account address
 ```
-  
-## Other Fees 
+
+## Other Fees
 
 |Type|Fee|
 | :------|:------:|

--- a/docs/mechanism&algorithm/sr.md
+++ b/docs/mechanism&algorithm/sr.md
@@ -1,26 +1,26 @@
 
 ## How to Become a Super Representative
 
- In TRON network, any account can apply to become a witness. Every account can vote for witnesses.   
+ In TRON network, any account can apply to become a witness. Every account can vote for witnesses.
 
- The top 27 witnesses are called SR, the witnesses from 28th to 127th are called Partner, the witnesses after 128th are called Candidates. Only SR can produce blocks.     
+ The top 27 witnesses are called SR, the witnesses from 28th to 127th are called Partner, the witnesses after 128th are called Candidates. Only SR can produce blocks.
 
- The votes will be counted every 6 hours, so super representatives may also change every 6 hours.  
+ The votes will be counted every 6 hours, so super representatives may also change every 6 hours.
 
  To prevent vicious attack, TRON network burns 9999 TRX from the account that applies to become a super representative candidate.
 
 ## Super Representatives Election
 
- To vote, you need to have TRON Power(TP). To get TRON Power, you need to freeze TRX. Every 1 frozen TRX accounts for one TRON Power(TP). Every account in TRON network has the right to vote for a super representative candidate. After you unfreeze your frozen TRX, you will lose the responding TRON Power(TP), so your previous vote will be invalid.  
+ To vote, you need to have TRON Power(TP). To get TRON Power, you need to freeze TRX. Every 1 frozen TRX accounts for one TRON Power(TP). Every account in TRON network has the right to vote for a super representative candidate. After you unfreeze your frozen TRX, you will lose the responding TRON Power(TP), so your previous vote will be invalid.
 
- Note: Only your latest vote will be counted in TRON network which means your previous vote will be over written by your latest vote.  
+ Note: Only your latest vote will be counted in TRON network which means your previous vote will be over written by your latest vote.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 
 ```text
-freezebalance 10,000,000 3 // Freeze 10 TRX to get 10 TRON Power(TP)  
-votewitness witness1 4 witness2 6 // Vote 4 votes for witness1, 6 votes for witness2  
-votewitness witness1 3 witness2 7 // Vote 3 votes for witness1, 7 votes for witness2  
+freezebalance 10,000,000 3 // Freeze 10 TRX to get 10 TRON Power(TP)
+votewitness witness1 4 witness2 6 // Vote 4 votes for witness1, 6 votes for witness2
+votewitness witness1 3 witness2 7 // Vote 3 votes for witness1, 7 votes for witness2
 ```
 
 The final output above is: Vote 3 votes for witness1, 7 votes for witness2
@@ -29,38 +29,38 @@ The final output above is: Vote 3 votes for witness1, 7 votes for witness2
 
 The default ratio is 20%, which can be modified by the witnesses.
 
-If a witness get 20% of the reward, and the other 80% will be awarded to the voters. If the brokerage ratio is set to 100%, the rewards are all obtained by the witness; if set to 0, the rewards are all sent to the voters.   
+If a witness get 20% of the reward, and the other 80% will be awarded to the voters. If the brokerage ratio is set to 100%, the rewards are all obtained by the witness; if set to 0, the rewards are all sent to the voters.
 
 ## Reward for Witnesses
 
-**Votes Reward:**  
+**Votes Reward:**
 
-Vote rewards are 160 TRX every block, with a block generated every 3 seconds, the total vote rewards per day is  4,608,000 TRX. 
+Vote rewards are 160 TRX every block, with a block generated every 3 seconds, the total vote rewards per day is  4,608,000 TRX.
 
-For each SR and Partner, the daily Vote Rewards = 4,608,000 * ( votes /  total votes) x 20%  TRX  
+For each SR and Partner, the daily Vote Rewards = 4,608,000 * ( votes /  total votes) x 20%  TRX
 
 
-**Block Producing Reward:**   
+**Block Producing Reward:**
 
-Every time after a super representative produces a block, it will be reward 16 TRX. The 27 super representatives take turns to produce blocks every 3 seconds. The annual block producing reward is 168,192,000 TRX in total.  
+Every time after a super representative produces a block, it will be reward 16 TRX. The 27 super representatives take turns to produce blocks every 3 seconds. The annual block producing reward is 168,192,000 TRX in total.
 
 Every time after a super representative produces a block, the 16 TRX block producing reward will be sent to it's sub-account. The sub-account is a read-only account, it allows a withdraw action from sub-account to super representative account every 24 hours.
 
-16 (TRX/block) * 28,800 (blocks/day) = 460,800 (TRX/Day)   
+16 (TRX/block) * 28,800 (blocks/day) = 460,800 (TRX/Day)
 
-For each super representative, the daily Block Rewards = (460,800 / 27) x 20%  TRX    
+For each super representative, the daily Block Rewards = (460,800 / 27) x 20%  TRX
 
-Reward may be less than the theoretical number due to missed blocks and maintenance period.      
+Reward may be less than the theoretical number due to missed blocks and maintenance period.
 
 ## Reward for Voters
 
-If you vote for a Super Representative:  
+If you vote for a Super Representative:
 
-the daily Voter Rewards =  (((the number of votes you vote to a witness) * 4,608,000 / total votes) * 80%) + ((460,800 / 27) * 80%) * (the number of votes you vote to a witness) / (the total number of votes a witness receives) TRX    
+the daily Voter Rewards =  (((the number of votes you vote to a witness) * 4,608,000 / total votes) * 80%) + ((460,800 / 27) * 80%) * (the number of votes you vote to a witness) / (the total number of votes a witness receives) TRX
 
-If you vote for a Partner:   
+If you vote for a Partner:
 
-the daily Voter Rewards =  (((the number of votes you vote to a witness) * 4,608,000 / total votes) * 80%) TRX    
+the daily Voter Rewards =  (((the number of votes you vote to a witness) * 4,608,000 / total votes) * 80%) TRX
 
 ## Committee
 
@@ -70,38 +70,38 @@ Committee can modify the TRON network parameters, like transacton fees, block pr
 
 <h3> 2. Create a Proposal </h3>
 
-Only SRs, Partners and Candidates can create a proposal.      
+Only SRs, Partners and Candidates can create a proposal.
 
-The network parameters can be modified([min,max]).     
+The network parameters can be modified([min,max]).
 
-{0,1}: 1 means 'allowed' or 'actived', 0 means no.      
+{0,1}: 1 means 'allowed' or 'actived', 0 means no.
 
-|  #    | Command  |  Value  |   
-|  ----  | ----    | ---- | 
-|  0     | getMaintenanceTimeInterval <br> (To modify the maintenance interval of SR)	| 6  Hours <br> [3 * 27, 24 * 3600] s | 
-|  1     | getAccountUpgradeCost <br> (To modify the cost of applying for SR account) | 9999  TRX <br> [0, 100000000000] TRX | 
+|  #    | Command  |  Value  |
+|  ----  | ----    | ---- |
+|  0     | getMaintenanceTimeInterval <br> (To modify the maintenance interval of SR)	| 6  Hours <br> [3 * 27, 24 * 3600] s |
+|  1     | getAccountUpgradeCost <br> (To modify the cost of applying for SR account) | 9999  TRX <br> [0, 100000000000] TRX |
 |  2     | getCreateAccountFee <br> (To modify the account creation fee) | 0.1  TRX <br> [0, 100000000000] TRX |
 |  3     | getTransactionFee <br> (To modify the amount of TRX used to gain extra bandwidth) | 10  Sun/Byte <br> [0, 100000000000] TRX |
-|  4     | getAssetIssueFee <br> (To modify asset issuance fee) | 1024  TRX <br> [0, 100000000000] TRX| 
+|  4     | getAssetIssueFee <br> (To modify asset issuance fee) | 1024  TRX <br> [0, 100000000000] TRX|
 |  5     | getWitnessPayPerBlock <br> (To modify SR block generation reward) | 16 TRX <br> [0, 100000000000] TRX |
 |  6     | getWitnessStandbyAllowance <br> (To modify the rewards given to the top 27 SRs and <br> the following 100 partners) | 115200  TRX <br> [0, 100000000000] TRX |
 |  7     | getCreateNewAccountFeeInSystemContract <br> (To modify the cost of account creation) | 0 TRX  |
-|  8     | getCreateNewAccountBandwidthRate <br> (To modify the consumption of bandwith of account creation) | 1&nbsp;Bandwith/Byte | 
-|  9     | getAllowCreationOfContracts <br> (To activate the Virtual Machine (VM)) | 1 <br> {0, 1} | 
-|  10	 | getRemoveThePowerOfTheGr <br> (To remove the GR Genesis votes) |	1 <br> {0, 1}| 
+|  8     | getCreateNewAccountBandwidthRate <br> (To modify the consumption of bandwidth of account creation) | 1&nbsp;Bandwidth/Byte |
+|  9     | getAllowCreationOfContracts <br> (To activate the Virtual Machine (VM)) | 1 <br> {0, 1} |
+|  10	 | getRemoveThePowerOfTheGr <br> (To remove the GR Genesis votes) |	1 <br> {0, 1}|
 |  11	 | getEnergyFee <br> (To modify the fee of 1 energy) | 10 Sun <br> [0, 100000000000] TRX |
 |  12	 | getExchangeCreateFee <br> (To modify the cost of trading pair creation) | 1024 TRX <br> [0, 100000000000] TRX |
 |  13	 | getMaxCpuTimeOfOneTx <br> (To modify the maximum execution time of one transaction) | 50 ms <br> [0, 1000] ms |
 |  14	 | getAllowUpdateAccountName <br> (To allow to change the account name) | 0 <br> {0, 1} |
-|  15	 | getAllowSameTokenName <br> (To allow the same token name) | 1 <br> {0, 1} | 
+|  15	 | getAllowSameTokenName <br> (To allow the same token name) | 1 <br> {0, 1} |
 |  16	 | getAllowDelegateResource <br> (To allow resource delegation) | 1 <br> {0, 1} |
-|  18	 | getAllowTvmTransferTrc10 <br> (To allow the TRC-10 token transfer in smart contracts) | 1 <br> {0, 1} | 
-|  19	 | getTotalEnergyCurrentLimit <br> (To modify current total energy limit) | 50000000000 | 
-|  20	 | getAllowMultiSign <br> (To allow the initiation of multi-signature) | 1 <br> {0, 1} | 
+|  18	 | getAllowTvmTransferTrc10 <br> (To allow the TRC-10 token transfer in smart contracts) | 1 <br> {0, 1} |
+|  19	 | getTotalEnergyCurrentLimit <br> (To modify current total energy limit) | 50000000000 |
+|  20	 | getAllowMultiSign <br> (To allow the initiation of multi-signature) | 1 <br> {0, 1} |
 |  21	 | getAllowAdaptiveEnergy <br> (To allow adaptive adjustment for total Energy) | 0 <br> {0, 1} |
-|  22	 | getUpdateAccountPermissionFee <br> (To modify the fee for updating account permission) | 100 TRX |  
-|  23	 | getMultiSignFee <br> (To modify the fee for multi-signature) | 1 TRX | 
-|  24	 | getAllowProtoFilterNum <br> (To enable protocol optimization) | 0 <br> {0, 1} | 
+|  22	 | getUpdateAccountPermissionFee <br> (To modify the fee for updating account permission) | 100 TRX |
+|  23	 | getMultiSignFee <br> (To modify the fee for multi-signature) | 1 TRX |
+|  24	 | getAllowProtoFilterNum <br> (To enable protocol optimization) | 0 <br> {0, 1} |
 |  26	 | getAllowTvmConstantinople <br> (To support the new commands of Constantinople) | 1 <br> {0, 1} |
 |  27	 | getAllowShieldedTransaction <br> (To enable shielded transaction) | 0 <br> {0, 1} |
 |  28	 | getShieldedTransactionFee <br> (To modify shielded transaction fee) | 10 TRX <br> [0, 10000] TRX |
@@ -111,31 +111,31 @@ The network parameters can be modified([min,max]).
 |  32    | getAllowTvmSolidity059 <br> (To allow TVM to support solidity compiler 0.5.9) | 0 <br> {0, 1} |
 |  33    | getAdaptiveResourceLimitTargetRatio <br> (To modify the target energy limit) | 10 <br> [1, 1000] |
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 ```text
-createproposal id value  
-id: the serial number (0 ~ 18)  
-value: the parameter value  
+createproposal id value
+id: the serial number (0 ~ 18)
+value: the parameter value
 ```
 
 Note: In TRON network, 1 TRX = 1000_000 SUN
 
 <h3> 3. Vote for a Proposal </h3>
 
-Proposal only support YES vote. Since the creation time of the proposal, the proposal is valid within 3 days. If the proposal does not receive enough YES votes within the period of validity, the proposal will be invalid beyond the period of validity. Yes vote can be cancelled.  
+Proposal only support YES vote. Since the creation time of the proposal, the proposal is valid within 3 days. If the proposal does not receive enough YES votes within the period of validity, the proposal will be invalid beyond the period of validity. Yes vote can be cancelled.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 ```text
 approveProposal id is_or_not_add_approval
-id: proposal id  
-is_or_not_add_approval: YES vote or cancel YES vote  
+id: proposal id
+is_or_not_add_approval: YES vote or cancel YES vote
 ```
 
 <h3> 4. Cancel Proposal </h3>
 
-Proposal creator can cancel the proposal before it is passed.  
+Proposal creator can cancel the proposal before it is passed.
 
-Example (Using wallet-cli):  
+Example (Using wallet-cli):
 ```text
 deleteProposal id
 id: proposal id
@@ -143,8 +143,8 @@ id: proposal id
 
 <h3> 5. Query Proposal </h3>
 
-- Query all the proposals list (ListProposals)  
-- Query all the proposals list by pagination (GetPaginatedProposalList)  
-- Query a proposal by proposal id (GetProposalById)  
+- Query all the proposals list (ListProposals)
+- Query all the proposals list by pagination (GetPaginatedProposalList)
+- Query a proposal by proposal id (GetProposalById)
 
-For more api detail, please refer to [Tron-http](Tron-http.md)  
+For more api detail, please refer to [Tron-http](Tron-http.md)

--- a/docs/q&a/qa.md
+++ b/docs/q&a/qa.md
@@ -188,7 +188,7 @@ Answer: Using the following command
 
 **Ask: Can SolidityNode and FullNode be deployed in one machine? Will they share the data?**
 
-Answer: They can be deployed in one machine. You can specify the data storage path in configuration file `db.directory = "database"，index.directory = "index"`. You can run FullNode.jar and SolidityNode.jar in different paths to separate the data and log. Remember to change the port in `config.conf`, because two nodes can not work using the same port. SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode. New developers should deploy FullNode only.
+Answer: They can be deployed in one machine. You can specify the data storage path in configuration file `db.directory = "database"，index.directory = "index"`. You can run FullNode.jar and SolidityNode.jar in different paths to separate the data and log. Remember to change the port in `config.conf`, because two nodes can not work using the same port. SolidityNode is deprecated. Now a FullNode supports all RPCs of a SolidityNode. New developers should deploy FullNode only.
 
 
 

--- a/docs/q&a/qa.md
+++ b/docs/q&a/qa.md
@@ -2,23 +2,23 @@
 
 **Ask: How can I generate an account?**
 
-Answer: You can use [Wallet-cli](https://github.com/tronprotocol/wallet-cli) or [Tronscan](https://tronscan.org/#/wallet/new)  
+Answer: You can use [Wallet-cli](https://github.com/tronprotocol/wallet-cli) or [Tronscan](https://tronscan.org/#/wallet/new)
 
 **Ask: What is the network flow?**
 
-Answer: Network flow depends on transaction volume. As a reference, the average size of a transaction currently is 200 bytes.  
+Answer: Network flow depends on transaction volume. As a reference, the average size of a transaction currently is 200 bytes.
 
 **Ask: After you create a token, how to change its status from 'not started yet' to 'participate'?**
 
-Answer: You need to wait till the time reaches the start time of participation you set when create a token. After a token is created, only the token url and description can be modified.  
+Answer: You need to wait till the time reaches the start time of participation you set when create a token. After a token is created, only the token url and description can be modified.
 
 **Ask: Is there a place to see if all the SuperNodes are producing blocks?**
 
-Answer: Please refer to [Tronscan](https://tronscan.org/#/sr/representatives)  
+Answer: Please refer to [Tronscan](https://tronscan.org/#/sr/representatives)
 
 **Ask: Is the block producing time interval always remain the same?**
 
-Answer: The current block producing time interval is 3 seconds. In the future, it may be improved to 1 second.  
+Answer: The current block producing time interval is 3 seconds. In the future, it may be improved to 1 second.
 
 **Ask: Will the block producing reward reduce half?**
 
@@ -26,11 +26,11 @@ Answer: No.
 
 **Ask: If one of the top 27 SuperNodes goes wrong, will it be removed from the SRs list?**
 
-Answer: If people stop voting for it, it will drop out of the top 27 SRs.   
+Answer: If people stop voting for it, it will drop out of the top 27 SRs.
 
-**Ask: Is there a threshold to become a SR?**  
+**Ask: Is there a threshold to become a SR?**
 
-Answer: When the amount of votes you get ranks into top 27, you will become a SR.  
+Answer: When the amount of votes you get ranks into top 27, you will become a SR.
 
 **Ask: 27 SRs shares the block producing reward equally or by their computing power?**
 
@@ -46,7 +46,7 @@ Answer: No.
 
 **Ask: How long does SR's power last?**
 
-Answer: Every 6 hours, the votes will be counted to check the qualifications of all the SRs. 
+Answer: Every 6 hours, the votes will be counted to check the qualifications of all the SRs.
 
 **Ask: What is the proof of a transaction？**
 
@@ -54,13 +54,13 @@ Answer: Transaction hash.
 
 **Ask: Why I Can't freeze TRX longer than 3 days**
 
-Answer: Frozen duration must be 3 days now. It means you can not unfreeze until the 3 days duration expires. If you don't unfreeze after 3 days, the frozen TRX will remain in frozen status until you unfreeze it.   
+Answer: Frozen duration must be 3 days now. It means you can not unfreeze until the 3 days duration expires. If you don't unfreeze after 3 days, the frozen TRX will remain in frozen status until you unfreeze it.
 
 **Ask: How to watch my account for transactions**
 
-Answer: To meet your needs, you can use TRON event subscription plugin. For more detail, please refer to [https://tronprotocol.github.io/documentation-EN/architecture/plugin/#tron-event-subscription](https://tronprotocol.github.io/documentation-EN/architecture/plugin/#tron-event-subscription)  
+Answer: To meet your needs, you can use TRON event subscription plugin. For more detail, please refer to [https://tronprotocol.github.io/documentation-EN/architecture/plugin/#tron-event-subscription](https://tronprotocol.github.io/documentation-EN/architecture/plugin/#tron-event-subscription)
 
-**Ask: How to calculate the transaction fee?**  
+**Ask: How to calculate the transaction fee?**
 
 Answer: please refer to [https://tronprotocol.github.io/documentation-EN/mechanism&algorithm/resource/](https://tronprotocol.github.io/documentation-EN/mechanism&algorithm/resource/)
 
@@ -70,19 +70,19 @@ Answer: tx-size  = grpcClient.getTransactionById(txId).get().getSerializedSize()
 
 **Ask: How to reset my vote?**
 
-Answer: You need to vote again, set your votes number to 0.  
+Answer: You need to vote again, set your votes number to 0.
 
 
 ## Configuration Questions
 
-**Ask: If I replace the field value of 'genesis.block.witnesses' with the address generated in [Tronscan](https://tronscan.org/) in config.conf, do I need to delete other addresses? Do I need to delete the field 'url' and 'voteCount'?**    
+**Ask: If I replace the field value of 'genesis.block.witnesses' with the address generated in [Tronscan](https://tronscan.org/) in config.conf, do I need to delete other addresses? Do I need to delete the field 'url' and 'voteCount'?**
 
-Answer: No need to delete other addresses, these addresses will be a part of your net, but if you do not own the private keys of these addresses, they will act like abandoned addresses.   
-Note: The addresses of Zion、Sun and Blackhole can not be deleted, but can be modified.  
+Answer: No need to delete other addresses, these addresses will be a part of your net, but if you do not own the private keys of these addresses, they will act like abandoned addresses.
+Note: The addresses of Zion、Sun and Blackhole can not be deleted, but can be modified.
 
 **Ask: How can I specify the data storage path when start a node?**
 
-Answer: You can add the data storage path when you start the node, like:  
+Answer: You can add the data storage path when you start the node, like:
 ```text
 java -jar FullNode.jar -c config.conf -d /data/output
 ```
@@ -93,19 +93,19 @@ Answer: Steps to send logs to stdout:
 
 Download [https://github.com/tronprotocol/java-tron/blob/develop/src/main/resources/logback.xml](https://github.com/tronprotocol/java-tron/blob/develop/src/main/resources/logback.xml)
 
-Uncomment the configuration:  
+Uncomment the configuration:
 
-appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender"  
+appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender"
 
-Go to the configuration: root level="INFO"  
-uncomment the configuration: appender-ref ref="STDOUT"  
-comment the configuration: appender-ref ref="ASYNC"  
+Go to the configuration: root level="INFO"
+uncomment the configuration: appender-ref ref="STDOUT"
+comment the configuration: appender-ref ref="ASYNC"
 
-Move logback.xml to the same directory with FullNode.jar  
+Move logback.xml to the same directory with FullNode.jar
 
 Launch FullNode.jar with additional parameter: --log-config logback.xml, for example:
 ```text
-java -jar FullNode.jar --log-config logback.xml  
+java -jar FullNode.jar --log-config logback.xml
 ```
 
 **Ask: How to change log level**
@@ -163,32 +163,32 @@ genesis.block = {
 
 **Ask: java-tron build failed with unit test issue**
 
-Answer: Please use './gradlew build -x test' to skip the test cases. 
+Answer: Please use './gradlew build -x test' to skip the test cases.
 
 ## Deployment Questions
 
 **Ask: How to test if the deployment works normally, if there is a test api or command like redis: get ping return pong?**
 
-Answer: Java-tron does not provide a default api to test. Once the service start, grpc commands can be sent. Based on that, there are several ways to test if the deployment is successful. You can also use the following command to test:  
-              
-```text                       
+Answer: Java-tron does not provide a default api to test. Once the service start, grpc commands can be sent. Based on that, there are several ways to test if the deployment is successful. You can also use the following command to test:
+       
+```text
 - tail -f logs/tron.log |grep "MyheadBlockNumber"
 ```
 
-**Ask: When to deploy private environment, what's the relationship of SuperNode and FullNode? Should I firstly deploy a SuperNode, and then deploy a FullNode？**  
+**Ask: When to deploy private environment, what's the relationship of SuperNode and FullNode? Should I firstly deploy a SuperNode, and then deploy a FullNode？**
 
-Answer: Under private environment, there should be at least one SuperNode, there is no amount limit for FullNode. 
+Answer: Under private environment, there should be at least one SuperNode, there is no amount limit for FullNode.
 
 **Ask: How to know wether my test SuperNode is running or not?**
 
 Answer: Using the following command
-```text             
+```text
 - tail -f logs/tron.log |grep "Try Produce Block"
 ```
 
 **Ask: Can SolidityNode and FullNode be deployed in one machine? Will they share the data?**
 
-Answer: They can be deployed in one machine. You can specify the data storage path in configuration file `db.directory = "database"，index.directory = "index"`. You can run FullNode.jar and SolidityNode.jar in different path to separate the data and log. Remember to change the port in config.conf, because two nodes can not work using the same port.   
+Answer: They can be deployed in one machine. You can specify the data storage path in configuration file `db.directory = "database"，index.directory = "index"`. You can run FullNode.jar and SolidityNode.jar in different paths to separate the data and log. Remember to change the port in `config.conf`, because two nodes can not work using the same port. SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode. New developers should deploy FullNode only.
 
 
 
@@ -196,19 +196,19 @@ Answer: They can be deployed in one machine. You can specify the data storage pa
 
 
 
-## Nodes Running Questions 
+## Nodes Running Questions
 
 **Ask: As under private environment, why the log keeps updating with all other public nodes? What's the difference of private and public environment？**
 
-Answer: If it is related to ip list: You need to update 'seed.ip' in config.conf, if it is the same as your public ip, and your computer is connected to the internet, it will try to connect other nodes, even if it fails to connect, the ip list will be stored into DB. If it is related to block and transaction: Under private environment, you need to modify the p2p version and parent hash. If they are the same as MainNet or TestNet, and the computer is connected to internet, the node will sync data from public node.  
+Answer: If it is related to ip list: You need to update 'seed.ip' in config.conf, if it is the same as your public ip, and your computer is connected to the internet, it will try to connect other nodes, even if it fails to connect, the ip list will be stored into DB. If it is related to block and transaction: Under private environment, you need to modify the p2p version and parent hash. If they are the same as MainNet or TestNet, and the computer is connected to internet, the node will sync data from public node.
 
 **Ask: Under private environment, should I submit application information to TRON to become a SR?**
 
-Answer: Under private environment, no need to submit application information to TRON to become a SR. 
+Answer: Under private environment, no need to submit application information to TRON to become a SR.
 
 **Ask：Which service port should be public to public network?**
 
-Answer: Default port 18888, 50051  
+Answer: Default port 18888, 50051
 
 **Ask: At the worst scenario, if the SuperNode can not be connected, the maximum time it allows the SuperNode to recover its service？**
 
@@ -220,26 +220,26 @@ Answer: Yes.
 
 **Ask: Does a node have wallet function?**
 
-Answer: No, but the node provides wallet rpc api.  
+Answer: No, but the node provides wallet rpc api.
 
 **Ask: Why does the block process time take so long?**
 
-Answer: Java-tron need more RAM to process transactions.  
+Answer: Java-tron need more RAM to process transactions.
 
 
 ## Test Net Questions
 
 **Ask: We want to test our SuperNode's performance under test environment, do we need to be voted to become a SR under test environment?**
 
-Answer: Yes. Under test environment, we can vote you to become SR.  
+Answer: Yes. Under test environment, we can vote you to become SR.
 
 **Ask: What is the defferent between Shasta and Test Net?**
 
-Answer: to be answered    
+Answer: to be answered
 
 **Ask: Where can I get the test TRX?**
 
-Answer: [http://testnet.tronex.io/join/getJoinPage](http://testnet.tronex.io/join/getJoinPage) 
+Answer: [http://testnet.tronex.io/join/getJoinPage](http://testnet.tronex.io/join/getJoinPage)
 
 
 ## Smart Contract Questions
@@ -249,11 +249,11 @@ Answer: [http://testnet.tronex.io/join/getJoinPage](http://testnet.tronex.io/joi
 
 **Ask: How to sign transaction from offline node and broadcast to online node?**
 
-Answer: You can use [tronweb](https://developers.tron.network/docs/api-sign-flow)  
+Answer: You can use [tronweb](https://developers.tron.network/docs/api-sign-flow)
 
 **Ask: How to sync wallet-cli with wallet on Tronscan?**
 
-Answer: By using wallet-cli api 'ImportWallet'.  
+Answer: By using wallet-cli api 'ImportWallet'.
 
 ## API Questions
 
@@ -263,11 +263,11 @@ Answer: Gateway can connect to SolidityNode and FullNode.
 
 **Ask: What is the different between 'getTransactionById' and 'getTransactionInfoById'?**
 
-Answer: The data they return is from different data modules. 'getTransactionById' focuses on general transaction data, while 'getTransactionInfoById' focuses on transaction fee data.  
+Answer: The data they return is from different data modules. 'getTransactionById' focuses on general transaction data, while 'getTransactionInfoById' focuses on transaction fee data.
 
 **Ask: How to broadcast raw transaction？**
 
-Answer: You can use 'wallet/broadcasthex'.  
+Answer: You can use 'wallet/broadcasthex'.
 
 **Ask: How to get token balance of an account?**
 
@@ -285,7 +285,7 @@ triggercontract contractaddress balanceOf(address) "youraddress" false 0 0 0 #
 17:02:42.699 INFO [o.t.c.s.WitnessService] Not sync
 ```
 Answer: This message means your node does not sync with the network. Before producing blocks, it needs to sync data. You can use the following command to chek the block height.
-```text              
+```text
 - tail -f logs/tron.log |grep "MyheadBlockNumber"
 ```
 
@@ -294,34 +294,3 @@ Answer: This message means your node does not sync with the network. Before prod
 **Ask: If the node is deployed in China, is there a firewall issue?**
 
 Answer: 39.106.220.120 locates in Beijing, others not.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
- 


### PR DESCRIPTION
To add:

```
> NOTE: SolidityNode is deprecated by FullNode. Now a FullNode supports all RPCs of a SolidityNode.
> New developers should deploy FullNode only.
```

And with some spelling error fixed.