### PR TITLE
docs: Fix typo in variable name Update getting_started_with_javatron.md

### DIFF
--- a/docs/getting_started/getting_started_with_javatron.md
+++ b/docs/getting_started/getting_started_with_javatron.md
@@ -138,7 +138,7 @@ Result:
 	"address": "TUoHaVjx7n5xz8LwPRDckgFrDWhMhuSuJM",
 	"balance": 93643857919,
 	"create_time": 1619681898000,
-	"latest_opration_time": 1655358327000,
+	"latest_operation_time": 1655358327000,
 	"is_witness": true,
 	"asset_issued_name": "TestTRC10T",
 	"latest_consume_free_time": 1652948766000,


### PR DESCRIPTION
I noticed a typo in the variable name `"latest_opration_time"`.

<img width="397" alt="Снимок экрана 2025-01-30 в 13 02 10" src="https://github.com/user-attachments/assets/7f8a6da9-cf43-4f77-9384-f0b3c6b6878c" />

The correct spelling should be `"latest_operation_time"`.

Here's the corrected line:  
```json
"latest_operation_time": 1655358327000,
```  

Fixed.