### PR TITLE
Fix: as in description 

### DIFF
--- a/docs/api/rpc.md
+++ b/docs/api/rpc.md
@@ -2,7 +2,6 @@
 
 **For the specific definition of API, please refer to the following link:**
 [api/api.proto](https://github.com/tronprotocol/protocol/blob/master/api/api.proto)
-[core/Contract.proto](https://github.com/tronprotocol/protocol/blob/master/core/Contract.proto).
 
 !!! note
     SolidityNode is deprecated. Now a FullNode supports all RPCs of a SolidityNode. New developers should deploy FullNode only.

--- a/docs/clients/wallet-cli-command.md
+++ b/docs/clients/wallet-cli-command.md
@@ -1,6 +1,6 @@
 # Wallet Commands
 
-Below, please find all types of Wallet-Cli commands：
+Below, please find all types of wallet-cli commands：
 
 - [Wallet](#wallet)
 - [Account](#account)

--- a/docs/clients/wallet-cli.md
+++ b/docs/clients/wallet-cli.md
@@ -1,9 +1,9 @@
 
 ## What is Wallet-CLI?
-Wallet-Cli is an interactive command-line wallet that supports the TRON network for signing and broadcasting transactions in a secure local environment, as well as access to on-chain data. Wallet-Cli supports key management, you can import the private key into the wallet, Wallet-Cli will encrypt your private key with a symmetric encryption algorithm and store it in a keystore file. Wallet-Cli does not store on-chain data locally. It uses gRPC to communicate with a java-tron node. You need to configure the java-tron node to be linked in the configuration file. The following figure shows the process of the use of Wallet-Cli to sign and broadcast when transferring TRX:
+wallet-cli is an interactive command-line wallet that supports the TRON network for signing and broadcasting transactions in a secure local environment, as well as access to on-chain data. wallet-cli supports key management, you can import the private key into the wallet, wallet-cli will encrypt your private key with a symmetric encryption algorithm and store it in a keystore file. wallet-cli does not store on-chain data locally. It uses gRPC to communicate with a java-tron node. You need to configure the java-tron node to be linked in the configuration file. The following figure shows the process of the use of wallet-cli to sign and broadcast when transferring TRX:
 ![](https://i.imgur.com/NRKmZmE.png)
 
-The user first runs the `Login` command to unlock the wallet, and then runs the `SendCoin` command to send TRX, Wallet-Cli will build and sign the transaction locally, and then call the BroadcastTransaction gRPC API of the java-tron node to broadcast the transaction to the network. After the broadcast is successful, the java-tron node will return the transaction hash to Wallet-Cli, and Wallet-Cli will display the transaction hash to the user.
+The user first runs the `Login` command to unlock the wallet, and then runs the `SendCoin` command to send TRX, wallet-cli will build and sign the transaction locally, and then call the BroadcastTransaction gRPC API of the java-tron node to broadcast the transaction to the network. After the broadcast is successful, the java-tron node will return the transaction hash to wallet-cli, and wallet-cli will display the transaction hash to the user.
 
-Install and run: [Wallet-Cli](https://github.com/tronprotocol/wallet-cli)
+Install and run: [wallet-cli](https://github.com/tronprotocol/wallet-cli)
 

--- a/docs/contracts/tvm.md
+++ b/docs/contracts/tvm.md
@@ -81,7 +81,7 @@ pragma solidity^0.4.11;
 ```
 3.&nbsp;Deploy contract
 
-Wallet-cli-vm branch: [https://github.com/tronprotocol/wallet-cli/tree/wallet-cli-vm](https://github.com/tronprotocol/wallet-cli/tree/wallet-cli-vm)
+wallet-cli-vm branch: [https://github.com/tronprotocol/wallet-cli/tree/wallet-cli-vm](https://github.com/tronprotocol/wallet-cli/tree/wallet-cli-vm)
 java-tron-vm branch: [https://github.com/tronprotocol/java-tron/tree/develop_vm](https://github.com/tronprotocol/java-tron/tree/develop_vm)
 Password: password of client-end wallet
 ContractAddress: customized contract address (in TRON’s required format)

--- a/docs/getting_started/getting_started_with_javatron.md
+++ b/docs/getting_started/getting_started_with_javatron.md
@@ -2,7 +2,7 @@
 
 This page mainly explains how to start the java-tron node and use the command line tool `wallet-cli` to execute basic commands to interact with the java-tron node. Regarding the installation of java-tron, you can download the runnable file directly or build it from source code. Instructions for installing java-tron can be found on the [Install and Build](../using_javatron/installing_javatron.md) page. This tutorial on this page assumes java-tron and associated developer tools have been successfully installed.
 
-This page covers the basics of using java-tron, which includes generating accounts, joining the TRON Nile testnet, and sending TRX between accounts. Wallet-cli is also used in this document. Wallet-cli is a command-line tool of the TRON network. This tool provides user interactive commands, which can be used to interact with java-tron more conveniently.
+This page covers the basics of using java-tron, which includes generating accounts, joining the TRON Nile testnet, and sending TRX between accounts. wallet-cli is also used in this document. wallet-cli is a command-line tool of the TRON network. This tool provides user interactive commands, which can be used to interact with java-tron more conveniently.
 
 java-tron is a TRON network client written in Java. This means a computer running java-tron will become a TRON network node. TRON is a distributed network where information is shared directly between nodes rather than being managed by a central server. After the super representative's node generates a new block, it will send the block to its peers. On receiving a new block, each node checks that it is valid and adds it to their database. java-tron uses the information provided by each block to update its "state" - the balance of each account on the TRON network. There are two types of accounts on the TRON network: externally owned accounts and contract accounts. The contract account executes the contract code when a transaction is received. An external account is an account that a user manages locally in order to sign and submit transactions. Each external account is a public-private key pair, where the public key is used to derive a unique address for the user, and the private key is used to protect the account and securely sign messages. Therefore, in order to use the TRON network, it is first necessary to generate an external account (hereinafter referred to as "account"). This tutorial will guide users on how to create an account, deposit TRX tokens, and transfer TRX.
 
@@ -13,7 +13,7 @@ Enter the command `java -jar wallet-cli.jar` in the terminal to start a wallet-c
 ```
 $ java -jar wallet-cli.jar
 
-Welcome to TRON Wallet-Cli
+Welcome to TRON wallet-cli
 Please type one of the following commands to proceed.
 Login, RegisterWallet or ImportWallet
  

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,20 +3,20 @@
 java-tron is a TRON client implemented in Java, it provides completely open source code, you can download the [java-tron source code](https://github.com/tronprotocol/java-tron) on Github. This article will introduce the knowledge related to java-tron. Through this article, you will learn how to use java-tron and how to participate in the development and maintenance of java-tron, including the following parts:
 
 
-* [Getting Started Guide](/documentation-en/getting_started/getting_started_with_javatron/)
-* [Using java-tron](/documentation-en/using_javatron/installing_javatron/)
-* [Protocol Guide](/documentation-en/introduction/dpos/)
-* [java-tron Development](/documentation-en/developers/java-tron/)
-* [DAPP Development](/documentation-en/contracts/compiler/)
-* [APIs](/documentation-en/api/http/)
-* [Wallet-CLI](/documentation-en/clients/wallet-cli/)
+* [Getting Started With java-tron](getting_started/getting_started_with_javatron/)
+* [Using java-tron](using_javatron/installing_javatron/)
+* [API](api/http/)
+* [Core Protocol](introduction/dpos/)
+* [For java-tron Developers](developers/java-tron/)
+* [For Dapp Developers](contracts/compiler/)
+* [wallet-cli](clients/wallet-cli/)
+* [Releases](releases/upgrade-instruction/)
 
 
 For other TRON related information, please visit the official website [tron.network](https://tron.network/index?lng=en) or the following resource links:
 
 * [TRON Whitepaper](https://tron.network/static/doc/white_paper_v_2_0.pdf)
-* [TRON Architecture](https://coin.top/pdf/Architecture/Design_Book_of_TRON_Architecture1.4.pdf)
 * [TRON Improvement Proposals (TIPs)](https://github.com/tronprotocol/tips)
-* [TRON Developer Hub](https://developers.tron.network/docs)
+* [TRON Developer Hub](https://developers.tron.network/)
 
 

--- a/docs/introduction/overview.md
+++ b/docs/introduction/overview.md
@@ -759,9 +759,9 @@ Copy the code example above to remix to debug.
 Copy the code example above to SimpleWebCompiler to get ABI and ByteCode.
 Because TRON's compiler is a little different from Ethereum, so you can not get ABI and ByteCode by using Remix. But it will soon be supported.
 
-**Using Wallet-cli to Deploy**
+**Using wallet-cli to Deploy**
 
-Download Wallet-Cli and build
+Download wallet-cli and build
 
 ```shell
 # download source code

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,9 @@
+/* 禁用一级目录的大写转换 */
+/* 禁用一级目录的大写转换 */
+.wy-menu-vertical p.caption {
+    text-transform: none;
+}
+
+.wy-dropdown-menu>dd.call-to-action {
+    text-transform: none;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* 禁用一级目录的大写转换 */
+/* Disable uppercase conversion for top-level directories. */
 .wy-menu-vertical p.caption {
     text-transform: none;
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,4 @@
 /* 禁用一级目录的大写转换 */
-/* 禁用一级目录的大写转换 */
 .wy-menu-vertical p.caption {
     text-transform: none;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,11 +3,11 @@ site_url: https://tronprotocol.github.io/documentation-en/
 repo_url: https://github.com/tronprotocol/documentation-en
 
 nav:
-    - Getting Started:
-        - Getting Started with java-tron: getting_started/getting_started_with_javatron.md
+    - Getting Started With java-tron:
+        - getting_started/getting_started_with_javatron.md
     - Using java-tron:
-        - Deploying java-tron: using_javatron/installing_javatron.md
-        - Backup & Restore: using_javatron/backup_restore.md
+        - Deploying: using_javatron/installing_javatron.md
+        - Backup and Restore: using_javatron/backup_restore.md
         - Lite FullNode: developers/litefullnode.md
         - Private Network: using_javatron/private_network.md
         - Event Subscription: architecture/event.md
@@ -27,7 +27,7 @@ nav:
         - System Contract: mechanism-algorithm/system-contracts.md
         - Decentralized Exchange: mechanism-algorithm/dex.md
         - Account Permission Management: mechanism-algorithm/multi-signatures.md
-    - For Java-tron Developers:
+    - For java-tron Developers:
         - Developer Guide: developers/java-tron.md
         - TIPs Workflow: developers/tips.md
         - Issue Workflow: developers/issue-workflow.md
@@ -35,16 +35,17 @@ nav:
         - Configure the IDE: developers/run-in-idea.md
         - Development Example: developers/demo.md
         - Core Modules: developers/code-structure.md
-    - For DAPP developers:
+    - For Dapp Developers:
         - Dapp Development Tool: contracts/compiler.md
-    - Wallet-cli:
-        - What is Wallet-CLI: clients/wallet-cli.md
-        - Wallet Commands: clients/wallet-cli-command.md
+    - wallet-cli:
+        - What is wallet-cli: clients/wallet-cli.md
+        - wallet-cli Commands: clients/wallet-cli-command.md
     - Releases:
         - Deployment Manual for the New Version: releases/upgrade-instruction.md
         - Integrity Check: releases/signature_verification.md
         - History: releases/history.md
-    - Glossary: glossary.md
+    - Glossary: 
+        - glossary.md
 
 theme: readthedocs
 extra_javascript:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,13 @@ nav:
         - glossary.md
 
 theme: readthedocs
+
 extra_javascript:
     - 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'
+
+extra_css:
+    - stylesheets/extra.css
+
 markdown_extensions:
     - admonition
     - footnotes


### PR DESCRIPTION
1. Fix the writing of top-level directory when there is only one file in it to prevent  it from being nested within other top-level directory.  Top-level directory of Glossary is an example.
2. Synchronize contents of index.md  with nav contents  in mkdocs.yml
3. Remove the default uppercase conversion of top level in nav， For example: FOR JAVA-TRON DEVELOPERS --> For java-tron Developers
4. Normalize the spelling of wallet-cli
5. Some accumulated minor issues