### PR TITLE
Fix: add back introduction/index.md

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,6 @@ plugins:
         - developers/incentives.md
         - developers/resources.md
         - faq/index.md
-        - introduction/index.md
         - introduction/overview.md
         - mechanism-algorithm/shielded-TRC20-contract.md
         - mechanism-algorithm/trc10.md


### PR DESCRIPTION
Although this file is not used when creating a project with MkDocs, it is referenced in the repository's README.