### PR TITLE
Fix all spelling errors in documentation

### DIFF
--- a/docs/api/json-rpc.md
+++ b/docs/api/json-rpc.md
@@ -1184,7 +1184,7 @@ QUANTITY - the filter id.
 
 **Returns**
 
-- For filters created with eth_newFilte, return logs object list, each log object with following params:
+- For filters created with eth_newFilter, return logs object list, each log object with following params:
 
 | Field            | Type           | Description                                                                                 |
 | :--------------- | :------------- | :------------------------------------------------------------------------------------------ |

--- a/docs/architecture/event.md
+++ b/docs/architecture/event.md
@@ -9,7 +9,7 @@ TRON offers two primary event subscription methods, allowing developers to choos
 
 ## Local Event Plugin Subscription (Recommended)
 
-This method utilizes an extensible plugin architecture to persistntly store on-chain events in external systems, such as **MongoDB** or **Kafka**, either in real-time or in batches. Designed specifically for production environments, this solution caters to applications requiring high reliability, durable storage, and robust data analysis capabilities.
+This method utilizes an extensible plugin architecture to persistently store on-chain events in external systems, such as **MongoDB** or **Kafka**, either in real-time or in batches. Designed specifically for production environments, this solution caters to applications requiring high reliability, durable storage, and robust data analysis capabilities.
 
 This method has the following advantages:
 
@@ -421,7 +421,7 @@ The main steps include:
 - [Deploying the Event Plugin](#deploying-the-event-subscription-plugin)
 - [Deploying the MongoDB](#installing-and-configuring-mongodb)
 - [Deploying the Event Query Service](#deploying-the-event-query-service)
-- [Starting and Verifing](#launch-and-verification)
+- [Starting and Verifying](#launch-and-verification)
 - [Using the TRON Event Query Service API](#using-the-tron-event-query-service-api)
 
 

--- a/docs/contracts/contract.md
+++ b/docs/contracts/contract.md
@@ -9,7 +9,7 @@ TRON smart contract support Solidity language in (Ethereum). You can find the la
 ## Features
 TRON virtual machine is based on Ethereum solidity language, it also has TRON's own features.
 
-### Defination of Smart Contract 
+### Definition of Smart Contract 
 TRON VM is compatible with Ethereum's smart contract, using protobuf to define the content of the contract:
 ``` solidity
 message SmartContract {
@@ -74,13 +74,13 @@ Through other two grpc message types CreateSmartContract and TriggerSmartContrac
 
 ### Usage of the Function of Smart Contract 
 
-* **constant function and inconstant function**
+* **constant function and non-constant function**
 
-There are two types of function according to whether any change will be made to the properties on the chain: constant function and inconstant function
+There are two types of function according to whether any change will be made to the properties on the chain: constant function and non-constant function
 Constant function uses view/pure/constant to decorate, will return the result on the node it is called and not be broadcasted in the form of a transaction
-Inconstant function will be broadcasted in the form of a transaction while being called, the function will change the data on the chain, such as transfer, changing the value of the internal variables of contracts, etc.
+Non-constant function will be broadcasted in the form of a transaction while being called, the function will change the data on the chain, such as transfer, changing the value of the internal variables of contracts, etc.
 
-Note: If you use create command inside a contract (CREATE instruction), even use view/pure/constant to decorate the dynamically created contract function, this function will still be treated as inconstant function, be dealt in the form of transaction.
+Note: If you use create command inside a contract (CREATE instruction), even use view/pure/constant to decorate the dynamically created contract function, this function will still be treated as non-constant function, be dealt in the form of transaction.
 
 * **message calls**
 
@@ -189,7 +189,7 @@ We recommend to use tron-studio instead of remix to build TRON smart contract.
 - block.timestamp (uint): current block timestamp
 - gasleft() returns (uint256): remaining gas
 - msg.data (bytes): complete call data
-- msg.gas (uint): remaining gas - since 0.4.21, not recommended, replaced by gesleft()
+- msg.gas (uint): remaining gas - since 0.4.21, not recommended, replaced by gasleft()
 - msg.sender (address): message sender (current call)
 - msg.sig (bytes4): first 4 bytes of call data (function identifier)
 - msg.value (uint): the amount of SUN send with message

--- a/docs/developers/demo.md
+++ b/docs/developers/demo.md
@@ -163,7 +163,7 @@ public class FullNodeHttpApiService implements Service {
 }
 ```
 
-### 2.3 Debuging and Testing
+### 2.3 Debugging and Testing
 
 Once the code changes are complete, you can start the `java-tron` node in IntelliJ IDEA for debugging. Then, use the `curl` command in your terminal to access the newly added HTTP API:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,19 +2,19 @@
 
 **energyUsage**
 
-The Energy conumption of the contract caller in one contract trigger.
+The Energy consumption of the contract caller in one contract trigger.
 
 **energyFee**
 
-The number of TRX burned from the contract caller for Energy conumption in one contract trigger.
+The number of TRX burned from the contract caller for Energy consumption in one contract trigger.
 
 **originEnergyUsage**
 
-The total Energy conumption of the contract developer in one contract trigger.
+The total Energy consumption of the contract developer in one contract trigger.
 
 **energyUsageTotal**
 
-The total Energy conumption of the contract developer and the contract caller combined.
+The total Energy consumption of the contract developer and the contract caller combined.
 
 **Feelimit**
 

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -428,7 +428,7 @@ message ReceiveDescription {
 ```
 
 - `value_commitment`: _value commitment_ of receiver's transfer amount.
-- `note_commitment`: commitment of the receiver's not.
+- `note_commitment`: commitment of the receiver's note.
 - `epk`: ephemeral public key, in order to generate note's decryption key.
 - `c_enc`: part of note ciphertext, encryption of diversifier, receiver's transfer amount, rcm, and memo.
 - `c_out`: part of note ciphertext, encryption of the receiver's public key and ephemeral private key.

--- a/docs/releases/history.md
+++ b/docs/releases/history.md
@@ -386,7 +386,7 @@ The Democritus version fixed the issue where the GitHub badge at the top of the 
 
 
 #### 3. Update telegram info and doc link in README
-The Democritus version udpated the README document to add Telegram contact information for the official TRON development discussion group.
+The Democritus version updated the README document to add Telegram contact information for the official TRON development discussion group.
 
 * Source Code:  [https://github.com/tronprotocol/java-tron/pull/6364](https://github.com/tronprotocol/java-tron/pull/6364)
 

--- a/docs/using_javatron/backup_restore.md
+++ b/docs/using_javatron/backup_restore.md
@@ -76,7 +76,7 @@ The table below lists the download addresses for FullNode data snapshots. Please
 
 - **LevelDB** and **RocksDB** data are not interchangeable. The database type for a FullNode is specified by the `db.engine` configuration item in the configuration file, with selectable values being `LEVELDB` or `ROCKSDB`.
 - Internal transactions can be enabled/disabled through the configuration items `vm.saveInternalTx` or `vm.saveFeaturedInternalTx` in the configuration file. Internal transactions are saved only when `vm.saveInternalTx` is enabled. If `saveFeaturedInternalTx` is also enabled, all types of internal transactions will be saved; otherwise, only `call`, `create`, and `suicide` transactions will be saved. Affected interface: [`gettransactioninfobyid`](https://developers.tron.network/reference/gettransactioninfobyid-1)
-- Historical accont balances can be enabled/disabled through the configuration item `storage.balance.history.lookup` in the configuration file. Affected interface: [`getaccountbalance`](https://developers.tron.network/reference/getaccountbalance)
+- Historical account balances can be enabled/disabled through the configuration item `storage.balance.history.lookup` in the configuration file. Affected interface: [`getaccountbalance`](https://developers.tron.network/reference/getaccountbalance)
 
 #### Lite FullNode Data Snapshots
 


### PR DESCRIPTION
## Summary
- Fix 16 spelling errors across 8 documentation files listed in mkdocs.yml navigation
- Only prose text outside code blocks was modified; no grammar or structural changes
- Errors identified via codespell automated scan + AI-assisted review

### Files changed
| File | Fix |
|------|-----|
| `glossary.md` | "conumption" → "consumption" (x4) |
| `architecture/event.md` | "persistntly" → "persistently", "Verifing" → "Verifying" |
| `api/json-rpc.md` | "eth_newFilte" → "eth_newFilter" |
| `mechanism-algorithm/system-contracts.md` | "not" → "note" |
| `contracts/contract.md` | "Defination" → "Definition", "inconstant" → "non-constant" (x4), "gesleft()" → "gasleft()" |
| `developers/demo.md` | "Debuging" → "Debugging" |
| `releases/history.md` | "udpated" → "updated" |
| `using_javatron/backup_restore.md` | "accont" → "account" |

## Test plan
- [ ] Verify all corrected words render correctly in mkdocs site
- [ ] Confirm no code blocks or inline code were modified