### PR TITLE
Refine JDK 8 wording in docs and drop JDK download links

### DIFF
--- a/docs/architecture/event.md
+++ b/docs/architecture/event.md
@@ -625,7 +625,7 @@ db.createUser({user:"<eventlog-username>",pwd:"<eventlog-password>",roles:[{role
 
 The Event Query Service provides an HTTP interface for querying event data stored in MongoDB. This service requires a Java environment.
 
-**Note**: Please use Oracle JDK 8 on x86_64 architecture and JDK 17 on arm64 architecture.
+**Note**: Please use JDK 8 (latest minor version recommended) on x86_64 architecture and JDK 17 on arm64 architecture.
 
 ##### 1. Downloading the Source Code
 

--- a/docs/developers/run-in-idea.md
+++ b/docs/developers/run-in-idea.md
@@ -4,17 +4,17 @@ To simplify the Java development process and improve efficiency, selecting and c
 
 java-tron nodes support deployment on `Linux` or `MacOS` operating systems. The JDK version requirements are as follows:
 
-- On x86_64 architecture, currently only Oracle JDK 8 is supported.
+- On x86_64 architecture, currently only JDK 8 (latest minor version recommended) is supported.
 - On arm64 architecture, currently only JDK 17 is supported.
 
-The following configuration uses x86_64 architecture and Oracle JDK 8 as an example.
+The following configuration uses x86_64 architecture and JDK 8 (latest minor version recommended) as an example.
 
 ## Prerequisites
 
 Before you begin, please ensure your development environment meets the following requirements:
 
   - Operating System: `Linux` or `MacOS`
-  - Oracle JDK 8 is installed
+  - JDK 8 (latest minor version recommended) is installed
   - `git` is installed
   - [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) is installed
 
@@ -41,7 +41,7 @@ To ensure Lombok's annotations work correctly, you must enable the annotation pr
 
 ### Step 3: Verify and Unify the JDK Version
 
-To ensure the project compiles and runs correctly, you must set the JDK version to Oracle JDK 8 in two key locations within IntelliJ IDEA.
+To ensure the project compiles and runs correctly, you must set the JDK version to JDK 8 (latest minor version recommended) in two key locations within IntelliJ IDEA.
 
 
 #### 1. Configure Project SDK
@@ -60,7 +60,7 @@ This is the JDK used to execute Gradle build tasks (e.g., build, clean).
 
 ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/IDE_JDK.png)
 
-> **Important Note**: The **Project SDK** and **Gradle JVM** settings must match and both be set to Oracle JDK 8(Consistent with version 1.8 shown in the figure, the difference between 1.8 and 8 is only in the naming convention. In the java-tron documentation, it is uniformly designated as 8 unless otherwise specified). Otherwise, you may encounter unexpected errors during the build process.
+> **Important Note**: The **Project SDK** and **Gradle JVM** settings must match and both be set to JDK 8 (latest minor version recommended)(Consistent with version 1.8 shown in the figure, the difference between 1.8 and 8 is only in the naming convention. In the java-tron documentation, it is uniformly designated as 8 unless otherwise specified). Otherwise, you may encounter unexpected errors during the build process.
 
 
 ## Getting and Compiling the Source Code

--- a/docs/developers/run-in-idea.md
+++ b/docs/developers/run-in-idea.md
@@ -60,7 +60,7 @@ This is the JDK used to execute Gradle build tasks (e.g., build, clean).
 
 ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/IDE_JDK.png)
 
-> **Important Note**: The **Project SDK** and **Gradle JVM** settings must match and both be set to JDK 8 (latest minor version recommended)(Consistent with version 1.8 shown in the figure, the difference between 1.8 and 8 is only in the naming convention. In the java-tron documentation, it is uniformly designated as 8 unless otherwise specified). Otherwise, you may encounter unexpected errors during the build process.
+> **Important Note**: The **Project SDK** and **Gradle JVM** settings must match and both be set to JDK 8 (latest minor version recommended; consistent with version 1.8 shown in the figure, the difference between 1.8 and 8 is only in the naming convention. In the java-tron documentation, it is uniformly designated as 8 unless otherwise specified). Otherwise, you may encounter unexpected errors during the build process.
 
 
 ## Getting and Compiling the Source Code

--- a/docs/using_javatron/installing_javatron.md
+++ b/docs/using_javatron/installing_javatron.md
@@ -4,7 +4,7 @@ This document guides developers on how to deploy a TRON java-tron node on `Linux
 
 Currently, a java-tron node supports running on both x86_64 and arm64 architectures(support for the arm64 architecture starts from version 4.8.1). JDK support varies by architecture:
 
-- For the x86_64 architecture, currently only Oracle JDK 8 is supported.
+- For the x86_64 architecture, currently only JDK 8 (latest minor version recommended) is supported.
 - For the arm64 architecture, currently only JDK 17 is supported.
 
 
@@ -58,7 +58,7 @@ uname -m
 
 - If your architecture is `x86_64` (Intel/AMD 64-bit):
 
-    - Install Java SE 8 (Oracle JDK 8): [https://www.oracle.com/java/technologies/javase/javase8-archive-downloads.html](https://www.oracle.com/java/technologies/javase/javase8-archive-downloads.html)
+    - Install Java SE 8 (JDK 8 (latest minor version recommended)).
     - Verify:
     ```bash
     java -version
@@ -67,7 +67,7 @@ uname -m
 
 - If your architecture is `arm64` or `aarch64` (Apple Silicon / ARM servers):
 
-    - Install Java SE 17 (JDK 17): [https://www.oracle.com/java/technologies/downloads/#java17](https://www.oracle.com/java/technologies/downloads/#java17)
+    - Install Java SE 17 (JDK 17).
     - Verify:
     ```bash
     java -version

--- a/docs/using_javatron/installing_javatron.md
+++ b/docs/using_javatron/installing_javatron.md
@@ -58,7 +58,7 @@ uname -m
 
 - If your architecture is `x86_64` (Intel/AMD 64-bit):
 
-    - Install Java SE 8 (JDK 8 (latest minor version recommended)).
+    - Install Java SE 8 (JDK 8, latest minor version recommended).
     - Verify:
     ```bash
     java -version

--- a/docs/using_javatron/private_network.md
+++ b/docs/using_javatron/private_network.md
@@ -5,7 +5,7 @@ This document will guide you through setting up a basic TRON private network. Th
 
 Before you begin, please ensure your development environment meets the following requirements:
 
-- **Java Development Kit (JDK)**: On x86_64 architecture, Oracle JDK 8 must be installed; on arm64 architecture, JDK 17 must be installed.
+- **Java Development Kit (JDK)**: On x86_64 architecture, JDK 8 (latest minor version recommended) must be installed; on arm64 architecture, JDK 17 must be installed.
 - **TRON Accounts**: You need to create at least two TRON network addresses in advance and securely store the addresses and their corresponding private keys. One address will serve as the initial SR node (Block Production), and the other will be a regular account.
 - **Address Creation Tools**: You can use any of the following tools to generate and manage your TRON accounts:
     - [Wallet-cli](https://github.com/tronprotocol/wallet-cli): An official command-line wallet tool, suitable for server environments.


### PR DESCRIPTION
## Summary

- Remove the `Oracle` prefix from `Oracle JDK 8` and append `(latest minor version recommended)` across JDK references.
- Remove the JDK 8 and JDK 17 Oracle download links from `installing_javatron.md`.

Files changed:
- `docs/architecture/event.md`
- `docs/developers/run-in-idea.md`
- `docs/using_javatron/installing_javatron.md`
- `docs/using_javatron/private_network.md`

## Test plan

- [ ] Build the mkdocs site locally and verify the affected pages render correctly.
- [ ] Spot-check that no `Oracle JDK 8` strings remain.