### PR TITLE
Add API overview page and fix broken installing_javatron anchor links

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,24 @@
+# java-tron APIs
+
+A java-tron node exposes three API surfaces. They share most underlying functionality but differ in transport, encoding, and ecosystem fit. Pick by client environment first; only fall back to "what each one supports" when you need a method the others don't have.
+
+## Pick one
+
+| Need | Recommended | Why |
+|---|---|---|
+| Calling from a browser, mobile, or any HTTP client | **HTTP API** | Plain `POST` + JSON, no codegen, the broadest method coverage on the node |
+| Reusing existing Ethereum tooling (web3.js, ethers.js, MetaMask, Hardhat, Foundry) | **JSON-RPC API** | Implements the `eth_*` / `net_*` / `web3_*` method set so EVM tools work unchanged |
+| Server-to-server in a typed language (Java, Go, Rust, C++) where latency or throughput matters | **gRPC API** | Persistent HTTP/2 connections, protobuf encoding, generated stubs |
+
+If you're undecided: start with **HTTP API**. It has the smallest setup cost and the widest method coverage. Switch to JSON-RPC only when EVM-tool compatibility is the goal, and to gRPC only when profiling shows the HTTP path is the bottleneck.
+
+Notes:
+
+- All three connect to the same underlying database. Choosing one doesn't restrict what data you can read — it restricts which method names and shapes are available.
+- The Solidity-suffixed variant of each API serves only solidified data (i.e. blocks that have crossed the irreversibility threshold). Use it when you need finality at the cost of ~1 minute of staleness.
+
+## Reference indexes
+
+- [HTTP API reference](http/index.md) — endpoints under `/wallet/*`, organized by feature
+- [JSON-RPC API reference](json-rpc/index.md) — `eth_*` / `net_*` / `web3_*` methods plus the Tron-specific `buildTransaction`
+- [gRPC API reference](rpc/index.md) — `protocol.Wallet` / `protocol.WalletSolidity` methods

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,9 +6,9 @@ A java-tron node exposes three API surfaces. They share most underlying function
 
 | Need | Recommended | Why |
 |---|---|---|
-| Calling from a browser, mobile, or any HTTP client | **HTTP API** | Plain `POST` + JSON, no codegen, the broadest method coverage on the node |
+| Calling from a browser, mobile, or any HTTP client | **HTTP API** | `POST` / `GET` (partial support), no codegen, the broadest method coverage on the node |
 | Reusing existing Ethereum tooling (web3.js, ethers.js, MetaMask, Hardhat, Foundry) | **JSON-RPC API** | Implements the `eth_*` / `net_*` / `web3_*` method set so EVM tools work unchanged |
-| Server-to-server in a typed language (Java, Go, Rust, C++) where latency or throughput matters | **gRPC API** | Persistent HTTP/2 connections, protobuf encoding, generated stubs |
+| Server-to-server in a typed language (Java, Go, Rust, C++) where latency or throughput matters | **gRPC API** | Persistent HTTP/2 connections, protobuf encoding, client code can be auto-generated from `.proto` with no hand-written networking |
 
 If you're undecided: start with **HTTP API**. It has the smallest setup cost and the widest method coverage. Switch to JSON-RPC only when EVM-tool compatibility is the goal, and to gRPC only when profiling shows the HTTP path is the bottleneck.
 
@@ -19,6 +19,6 @@ Notes:
 
 ## Reference indexes
 
-- [HTTP API reference](http/index.md) — endpoints under `/wallet/*`, organized by feature
-- [JSON-RPC API reference](json-rpc/index.md) — `eth_*` / `net_*` / `web3_*` methods plus the Tron-specific `buildTransaction`
-- [gRPC API reference](rpc/index.md) — `protocol.Wallet` / `protocol.WalletSolidity` methods
+- [HTTP API reference](http/index.md) — endpoints under `/wallet/*` and `/walletsolidity/*` (partial support), organized by feature
+- [JSON-RPC API reference](json-rpc/index.md) — `eth_*` / `net_*` / `web3_*` methods plus the Tron-specific `buildTransaction`, organized by feature
+- [gRPC API reference](rpc/index.md) — `protocol.Wallet` / `protocol.WalletSolidity` (partial support) methods, organized by feature

--- a/docs/getting_started/getting_started_with_javatron.md
+++ b/docs/getting_started/getting_started_with_javatron.md
@@ -164,7 +164,7 @@ This module guide you through launching a java-tron instance, turning your compu
 
 ### **1. Start the Node**
 
-For the startup command, please refer to [Staring a FullNode on the Nile test network](../../using_javatron/installing_javatron/#staring-a-fullnode-on-the-nile-test-network).
+For the startup command, please refer to [Starting a FullNode on the Nile test network](../using_javatron/installing_javatron.md#starting-a-fullnode-on-the-nile-test-network).
 
 ### **2. Verify Node Status**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ This documentation is written for java-tron node operators, protocol researchers
 
     - [HTTP API](api/http/index.md)
     - [JSON-RPC API](api/json-rpc/index.md)
+    - [gRPC API](api/rpc/index.md)
     - [Smart Contracts](contracts/contract.md)
     - [wallet-cli](clients/wallet-cli.md)
 
@@ -56,7 +57,7 @@ This documentation is written for java-tron node operators, protocol researchers
 ## Browse by topic
 
 - __[Using java-tron](using_javatron/installing_javatron.md)__ — Deployment, backup and restore, lite node, private network, event subscription, database configuration, node monitoring, maintenance tooling
-- __[API](api/http/index.md)__ — HTTP, gRPC, JSON-RPC
+- __[API](api/index.md)__ — HTTP, gRPC, JSON-RPC
 - __[Core Protocol](mechanism-algorithm/dpos.md)__ — DPoS consensus, Super Representatives, account model, resource model, smart contracts, system contracts, decentralized exchange, account permission management
 - __[For java-tron Developers](developers/java-tron.md)__ — Developer guide, TIPs workflow, issue workflow, governance workflow, IDE configuration, development examples, core modules
 - __[For DApp Developers](contracts/tools.md)__ — Development tooling

--- a/docs/releases/upgrade-instruction.md
+++ b/docs/releases/upgrade-instruction.md
@@ -93,10 +93,10 @@ After preparing the new version of the executable file and backing up the origin
 
 #### Super Representative Node (Block-Producing Node)
 
-For Block-Producing Node, please refer to [Starting a Block Production Node](../../using_javatron/installing_javatron/#starting-a-block-production-node)
+For Block-Producing Node, please refer to [Starting a Block Production Node](../using_javatron/installing_javatron.md#starting-a-block-production-node)
     
 #### Regular FullNode
-For Regular FullNode, please refer to [Starting a FullNode on the TRON main network](../../using_javatron/installing_javatron/#starting-a-fullnode-on-the-tron-main-network) 
+For Regular FullNode, please refer to [Starting a FullNode on the TRON main network](../using_javatron/installing_javatron.md#starting-a-fullnode-on-the-tron-main-network) 
 
 ### Step 6: Verify and Monitor
 

--- a/docs/using_javatron/toolkit.md
+++ b/docs/using_javatron/toolkit.md
@@ -114,9 +114,9 @@ java -jar build/libs/Toolkit.jar db mv -c framework/src/main/resources/config.co
 
 Once the migration is complete, restart your `java-tron` node. 
 
-[**FullNode Startup Command Example**](../installing_javatron/#starting-a-fullnode-on-the-tron-main-network)
+[**FullNode Startup Command Example**](installing_javatron.md#starting-a-fullnode-on-the-tron-main-network)
 
-[**Super Representative (SR) FullNode Startup Command Example**](../installing_javatron/#starting-a-block-production-node)
+[**Super Representative (SR) FullNode Startup Command Example**](installing_javatron.md#starting-a-block-production-node)
 
 ## Lite Fullnode Data Pruning
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
         - Node Monitoring: using_javatron/metrics.md
         - Node Maintenance Tool: using_javatron/toolkit.md
     - API:
+        - Overview: api/index.md
         - HTTP API:
             - Overview: api/http/index.md
             - Account:


### PR DESCRIPTION
## Summary

- Add a top-level `docs/api/index.md` overview page that helps readers pick between HTTP, JSON-RPC, and gRPC APIs by client environment, with notes on the Solidity-suffixed variants and partial coverage caveats
- Wire the new Overview into `mkdocs.yml` navigation, add the missing gRPC API entry on the homepage, and point the homepage "Browse by topic > API" link at the new overview
- Fix broken `installing_javatron` anchor links in `getting_started_with_javatron.md`, `releases/upgrade-instruction.md`, and `using_javatron/toolkit.md` (relative paths and a typo in `staring` → `starting`)

## Test plan

- [ ] `mkdocs build` succeeds with no warnings about the new/edited links
- [ ] Visually verify the API overview page renders and that the three reference index links resolve
- [ ] Click each fixed `installing_javatron#...` anchor and confirm it lands on the right section