### PR TITLE
Fix markdown list rendering across docs

### DIFF
--- a/docs/api/http/index.md
+++ b/docs/api/http/index.md
@@ -3,6 +3,7 @@
 This directory documents the FullNode HTTP endpoints under `framework/src/main/java/org/tron/core/services/http/`. One markdown file per endpoint, named after the last segment of the URL (e.g. `/wallet/getnodeinfo` → `getnodeinfo.md`).
 
 The following categories are intentionally not covered:
+
 - Exchange (DEX) endpoints
 - Market (order book) endpoints
 - Shielded (anonymous transaction) endpoints

--- a/docs/api/json-rpc/index.md
+++ b/docs/api/json-rpc/index.md
@@ -22,9 +22,9 @@ The URL path is always `/jsonrpc` (see `FullNodeJsonRpcHttpService.java`).
 - **Numeric encoding**: all numbers (block number, balance, gas, timestamp, etc.) use `0x`-prefixed hex strings; null values map to `0x` or `0x0`.
 - **Address encoding**: JSON-RPC interfaces accept `0x`-prefixed 20-byte hex addresses by default; base58check is also accepted (internally converted by `JsonRpcApiUtil.addressCompatibleToByteArray`).
 - **Block tags**: among the common `latest` / `earliest` / `pending` / `finalized`, **only a few methods support these tags**:
-  - Block-query methods such as `eth_getBlockByNumber` and `eth_getBlockReceipts` accept `latest` / `earliest` / `finalized`; `pending` is explicitly unsupported and throws `-32602 TAG pending not supported`.
-  - `eth_getBalance` / `eth_getStorageAt` / `eth_getCode` / `eth_call` **only support `latest`**; `earliest` / `pending` / `finalized` raise `-32602 TAG [earliest | pending | finalized] not supported`, and a specific height raises `-32602 QUANTITY not supported, just support TAG as latest`.
-  - `eth_newFilter` does not support `finalized` (raises `-32602 invalid block range params`).
+    - Block-query methods such as `eth_getBlockByNumber` and `eth_getBlockReceipts` accept `latest` / `earliest` / `finalized`; `pending` is explicitly unsupported and throws `-32602 TAG pending not supported`.
+    - `eth_getBalance` / `eth_getStorageAt` / `eth_getCode` / `eth_call` **only support `latest`**; `earliest` / `pending` / `finalized` raise `-32602 TAG [earliest | pending | finalized] not supported`, and a specific height raises `-32602 QUANTITY not supported, just support TAG as latest`.
+    - `eth_newFilter` does not support `finalized` (raises `-32602 invalid block range params`).
 
 ## Error responses
 

--- a/docs/api/json-rpc/smart-contract/eth_estimateGas.md
+++ b/docs/api/json-rpc/smart-contract/eth_estimateGas.md
@@ -12,6 +12,7 @@ Estimate a transaction's energy consumption (Tron's counterpart of Ethereum gas)
 | `params[0]` | object | yes | `CallArguments` (same as [`eth_call`](eth_call.md)); `from` / `to` / `value` / `data` are used to infer the contract type |
 
 `CallArguments.getContractType` inference rules:
+
 - `to` is empty and `data` is non-empty → `CreateSmartContract`
 - `to` is a contract address → `TriggerSmartContract`
 - `to` is a regular account and `value` is non-empty → `TransferContract` (returns `0x0` directly without entering EVM estimation)

--- a/docs/api/json-rpc/smart-contract/eth_estimateGas.md
+++ b/docs/api/json-rpc/smart-contract/eth_estimateGas.md
@@ -38,8 +38,8 @@ Hex-encoded energy usage:
 
 - Plain TRX transfer (`TransferContract`) → `0x0`
 - Contract call / deployment → depends on node config:
-  - `node.supportEstimateEnergy = true` returns `EstimateEnergyMessage.energyRequired`
-  - Default (false) → returns `TransactionExtention.energyUsed` (the actual usage of one constant-call)
+    - `node.supportEstimateEnergy = true` returns `EstimateEnergyMessage.energyRequired`
+    - Default (false) → returns `TransactionExtention.energyUsed` (the actual usage of one constant-call)
 
 The example below is the real response captured from the Nile testnet curl above (the TRX transfer takes the `TransferContract` path and returns `0x0` directly without entering the EVM):
 

--- a/docs/clients/wallet-cli.md
+++ b/docs/clients/wallet-cli.md
@@ -1492,7 +1492,7 @@ assetV2
 #### TRC-10 Token Transfer -` TransferAsset [OwnerAddress] ToAddress AssertID Amount`
 
 - `OwnerAddress` (Optional) - The account address initiating the transaction. Default: The address of the logged-in account.
--`ToAddress` - The address of the destination account.
+- `ToAddress` - The address of the destination account.
 - `AssertName` - The TRC-10 token ID. Example: 1000001
 - `Amount` - The number of TRC-10 tokens to be transferred.
 

--- a/docs/developers/advanced-configuration.md
+++ b/docs/developers/advanced-configuration.md
@@ -91,6 +91,7 @@ node.backup {
 }
 ```
 policy: 
+
 1. the one which synchronized first will become master.
 2. if synchronization is completed at the same time, the one with big priority will become master.
 

--- a/docs/mechanism-algorithm/dex.md
+++ b/docs/mechanism-algorithm/dex.md
@@ -85,6 +85,7 @@ Parameters are as follows:
 
 ### Example:
 Suppose the trading pair ID for `abc` and `TRX` is 1, with the current state:
+
 - `abc` balance is 10,000,000.
 - `TRX` balance is 1,000,000.
 
@@ -112,6 +113,7 @@ Parameters are as follows:
 
 ### Example:
 Suppose the trading pair ID for `abc` and `TRX` is 1, with the current state:
+
 - `abc` balance is 10,000,000.
 - `TRX` balance is 1,000,000.
 

--- a/docs/mechanism-algorithm/multi-signatures.md
+++ b/docs/mechanism-algorithm/multi-signatures.md
@@ -71,7 +71,7 @@ Explanation:
 
 - `type`: Permission type (owner/witness/active).
 - `id`: Permission ID, automatically assigned by the system.
-  - `owner` = 0, `witness` = 1, `active` starts from 2 and increments.
+    - `owner` = 0, `witness` = 1, `active` starts from 2 and increments.
 - `permission_name`: Permission name, maximum 32 bytes.
 - `threshold`: Permission threshold, operation is allowed only when the combined weight of the signing key ≥ this value.
 - `operations`: Used only for Active permissions, specifies executable contract types.

--- a/docs/mechanism-algorithm/shielded-transaction.md
+++ b/docs/mechanism-algorithm/shielded-transaction.md
@@ -15,6 +15,7 @@ In shielded transaction of transferring TronZ, there are two types of address:
 "z-addr" address uses Anonymous account model.
 
 In shielded transaction of transferring TronZ, there are three types of transfer transaction:
+
 - From "t-addr" to "z-addr":
 The transaction information of "t-addr" can be tracked, "z-addr" can not be tracked.
 

--- a/docs/releases/versions/v3.7.md
+++ b/docs/releases/versions/v3.7.md
@@ -11,6 +11,7 @@ As the core module, Framework performs as both a gateway to the blockchain and a
 The decentralized TRON protocol can be implemented by any teams without limitation of programming languages. Any clients in accordance with the TRON protocol can communicate with each other.
 A concise and efficient data transfer protocol is essential to a distributed network, even more for the blockchain. So, the implementation of the protocol is based on the Protocol Buffers, an open-source and excellent software protocol maintained by Google. 
 The specific business logic of the blockchain defined by the protocol includes:
+
 - the data format of message，including block, transaction, proposal, witness, vote, account, exchange and so on.
 - the communication protocols between blockchain nodes, including the node discovery protocol, the node data synchronization protocol, the node scoring protocol and so on.
 - the interface protocols that the blockchain provides to the external system or clients
@@ -35,6 +36,7 @@ Added a subscription trigger for the updating a solidified block, which triggers
 **gettransactioninfobyblocknum**
 
 This api is both added in the context: /wallet & /walletsolidity.
+
 * Description: Query the list of information of transactions in a specific block.
 * Parameter num: the height of the block.
 * Return: The list of transaction information.
@@ -42,6 +44,7 @@ This api is both added in the context: /wallet & /walletsolidity.
 **broadcasthex**
 
 /wallet/broadcasthex
+
 * Description: broadcast signed transaction with the format of the hex string
 * Parameter: signed transaction with the format of the hex string
 * Return: the result of the broadcast

--- a/docs/releases/versions/v4.0.0.md
+++ b/docs/releases/versions/v4.0.0.md
@@ -42,6 +42,7 @@ Forced upgrade
 - Add data field in transaction log trigger class for future memo note (#3200).
 
 The following TIPs are implemented in this release:
+
 - [TIP-135](https://github.com/tronprotocol/tips/blob/master/tip-135.md): Shielded TRC-20 contract standards, guarantee the privacy of the shielded transfer of TRC-20 tokens.
 - [TIP-137](https://github.com/tronprotocol/tips/blob/master/tip-137.md): Implements three zero-knowledge proof instructions in TVM to support the shielded TRC-20 contract (#3172).
 - [TIP-138](https://github.com/tronprotocol/tips/blob/master/tip-138.md): Implements the Pedersen hash computation instruction in TVM to support the shielded TRC-20 contract (#3172).

--- a/docs/releases/versions/v4.1.1.md
+++ b/docs/releases/versions/v4.1.1.md
@@ -10,16 +10,19 @@ Source code: [#3082](https://github.com/tronprotocol/java-tron/pull/3082)
 #### 2. New Node Type
 We added another type of node to the existing FullNode: Lite FullNode. Lite FullNode executes the same code with the FullNode. What sets it apart is that its launch is based on the status data snapshot, which contains all the status data and data history of the latest 256 blocks.
 The status data snapshot can be acquired by executing LiteFullNodeTool.jar (please see: [Use the LiteFullNode Tool](https://tronprotocol.github.io/documentation-en/developers/litefullnode/)).
+
 - TIP: [TIP-128](https://github.com/tronprotocol/tips/blob/master/tip-128.md)
 - Source code: [#3031](https://github.com/tronprotocol/java-tron/pull/3031)
  
 ### II. TVM
 #### Achieved compatibility with Ethereum Istanbul upgrade
 a. Added new instruction `CHAINID` to fetch the genesis block ID of the current chain, which avoids possible replay attacks of one transaction being repeated on different chains.
+
 - TIP: [TIP-174](https://github.com/tronprotocol/tips/blob/master/tip-174.md)
 - Source code: [#3351](https://github.com/tronprotocol/java-tron/pull/3351)
 
 b. Added new instruction `SELFBALANCE` to fetch the balance of the current contract address in the smart contract. For obtaining the balance of any address, please stick with instruction BALANCE.SELFBALANCE is safer to use. Energy consumption of using `BALANCE` might rise in the future.
+
 - TIP: [TIP-175](https://github.com/tronprotocol/tips/blob/master/tip-175.md)
 - Source code: [#3351](https://github.com/tronprotocol/java-tron/pull/3351)
  
@@ -27,6 +30,7 @@ c. Reduced Energy consumption of three precompiled contract instructions, namely
 BN128Addition: from 500 Energy to 150 Energy
 BN128Multiplication: from 40000 Energy to 6000 Energy
 BN128Pairing: from (80000 \* pairs + 100000) Energy to (34000 \* pairs + 45000) Energy
+
 - TIP: [TIP-176](https://github.com/tronprotocol/tips/blob/master/tip-176.md)
 - Source code: [#3351](https://github.com/tronprotocol/java-tron/pull/3351)
  

--- a/docs/releases/versions/v4.1.2.md
+++ b/docs/releases/versions/v4.1.2.md
@@ -18,6 +18,7 @@ The account historical balance query function can facilitate developers to query
 - /wallet/getblockbalance ： Query the balance-changing operations in a specific block.
 
 **Note:**
+
 1. This function is disabled by default and can be enabled through the node configuration file.
 2. After the function is enabled, users can only query the historical balance after the enabled time. If users need to query the complete historical balance information, they can use the data snapshot which contains the historical balance information to resynchronize the node.
 

--- a/docs/releases/versions/v4.1.3.md
+++ b/docs/releases/versions/v4.1.3.md
@@ -11,6 +11,7 @@ After this optimization, block producers sort the transactions to be packaged ac
 It is currently impossible to query the intermediate state information of a certain transaction from after it is issued to before it is on the chain.After a transaction is sent, if it is not on the chain, we cannot know whether it is waiting for packaging or has been discarded.
 
 In this upgrade, the Fullnode node provides 3 API to obtain detailed information about the pending pool:
+
 - /wallet/gettransactionfrompending: Obtain the transaction information from pending pool through the - transaction ID
 - /wallet/gettransactionlistfrompending: Get all transactions from the pending pool
 - /wallet/getpendingsize: Get the number of transactions in pending pool

--- a/docs/releases/versions/v4.4.0.md
+++ b/docs/releases/versions/v4.4.0.md
@@ -28,6 +28,7 @@ https://github.com/tronprotocol/java-tron/pull/3992
 ### TVM
 #### 1. Provide compatibility with EVM
 The GreatVoyage-v4.4.0 (Rousseau) version provides compatibility solution for those instructions that are different from EVM, so that the newly deployed contract supports the following features:
+
 - The `GASPRICE` instruction returns the unit price of energy.
 - The `try/catch-statement` supports catching all types of TVM exceptions.
 - Forbid the system contract “TransferContract” to transfer TRX to the smart contract account.
@@ -67,6 +68,7 @@ Source code：https://github.com/tronprotocol/java-tron/pull/4045
 
 #### 3. Optimize the `TriggerConstantContract` API
 In GreatVoyage-v4.4.0 (Rousseau), the following optimizations have been introduced to the `TriggerConstantContract` interface:
+
 -  Execute contract creation when `ContractAddress` is empty
 -  Remove the check of the incoming parameters `callvalue` and `tokenvalue`
 -  The log list and internal transaction list are added to `TransactionExtention`

--- a/docs/using_javatron/installing_javatron.md
+++ b/docs/using_javatron/installing_javatron.md
@@ -231,7 +231,7 @@ By adding the `--witness` parameter to the FullNode startup command above, the `
 **Important Notes**:
 
 * Ensure that you own a Super Representative (SR) account and have received sufficient votes. If your vote count ranks among the top 27, you need to start an SR Node to participate in block production.
-  * Note that even if your node doesn't make it into the top 27, a node started with the `--witness` parameter will still operate as a regular node; once its ranking reaches the top 27, it can immediately begin producing blocks.
+    * Note that even if your node doesn't make it into the top 27, a node started with the `--witness` parameter will still operate as a regular node; once its ranking reaches the top 27, it can immediately begin producing blocks.
 * Fill in the **private key** of your Super Representative account in the `localwitness` list of `config.conf`.
 
 Here is an example of the `localwitness` configuration:

--- a/docs/using_javatron/toolkit.md
+++ b/docs/using_javatron/toolkit.md
@@ -130,6 +130,7 @@ A FullNode's complete data can be split into two parts: a Snapshot Dataset or a 
 The Snapshot Dataset contains all account state data plus the history of the most recent 65,536 blocks. It occupies a small amount of space (approximately 3% of a FullNode's data). Since a Lite Fullnode starts using only the Snapshot Dataset, it benefits from low disk usage and fast startup speeds.
 
 The data pruning tool can split a FullNode's data into a **Snapshot Dataset** or a **History Dataset**. It also supports merging a history dataset back with a snapshot dataset. This enables the following use cases:
+
 * **Convert FullNode Data into Lite Fullnode Data**: Split the full node data to generate a snapshot dataset, which is all that's needed to run a light node.
 * **Periodically Pruning a Lite FullNode**: As a light node runs, its data grows. You can periodically prune it by using the tool to create a new, smaller snapshot dataset from the existing lite FullNode data.
 * **Converting Lite FullNode Data Back to FullNode Data**: To enable historical queries on a lite FullNode, you can convert it back to a FullNode. First, split a FullNode to create a history dataset. Then, merge that history dataset with your lite FullNode's snapshot dataset to create a complete FullNode database.


### PR DESCRIPTION
## Summary
- Add blank lines before lists so they render correctly in MkDocs/CommonMark
- Indent nested lists with 4 spaces so they render as sublists
- Fix a bullet that was missing a space after the dash (`-ToAddress` → `- ToAddress`)
- Touches API docs, mechanism/algorithm docs, release notes, and using_javatron guides — content unchanged, only markdown formatting

## Test plan
- [ ] Build the docs site locally and verify the affected pages render the lists/sublists correctly
- [ ] Spot-check `docs/api/json-rpc/index.md`, `docs/api/json-rpc/smart-contract/eth_estimateGas.md`, `docs/clients/wallet-cli.md`, and the v3.7/v4.x release notes