### PR TITLE
Stop loading nav-toc.js to restore Material native nav interaction

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -340,7 +340,6 @@ theme:
 
 extra_javascript:
     - javascripts/toc.js
-    - javascripts/nav-toc.js
     - javascripts/mathjax-sri.js
 
 extra_css:


### PR DESCRIPTION
## Summary
- Remove `javascripts/nav-toc.js` from `extra_javascript` in `mkdocs.yml` so the left navigation falls back to Material's native interaction behavior, since the TOC is no longer integrated into the nav.
- The `nav-toc.js` file itself is intentionally kept in the repo to make it easy to re-enable TOC-into-nav integration in the future if needed.

## Test plan
- [ ] Build the site locally and confirm the left navigation behaves as expected (Material default interaction).
- [ ] Verify no console errors related to the removed script.