### PR TITLE
Align network connection doc with libp2p and java-tron source code

### DIFF
--- a/docs/using_javatron/connecting_to_tron.md
+++ b/docs/using_javatron/connecting_to_tron.md
@@ -264,10 +264,10 @@ In some cases (e.g., local testing or a fixed private network), you may disable 
 ### Number of Node Connections
 The number of peer connections is controlled by the following parameters. They are usually tuned together:
 
-- `node.maxConnections`: the maximum number of peer connections (default: 30). Inbound connections from non-trusted peers are rejected once this limit is reached. A peer is considered trusted if its IP appears in `node.passive`, `node.active`, or `fastForward` (the IPs from all three are added to the trust list). Outbound connections bypass this check entirely: outbound to peers configured in `node.active` is bounded only by the size of the `node.active` list, while outbound to peers discovered via the discovery protocol is driven by `minConnections` and `minActiveConnections` (see below).
-- `node.minConnections`: the desired minimum total number of peer connections, counting both inbound and outbound (default: 8). When the total is below this value, the node initiates outbound connections to discovered peers to close the gap.
-- `node.minActiveConnections`: the desired minimum number of outbound connections to discovered peers (default: 3). The node will keep initiating outbound connections to discovered peers until this threshold is met, even if the total connection count has already reached or exceeded `minConnections`.
-- `node.maxConnectionsWithSameIp`: the maximum number of connections allowed from the same IP address (default: 2). It mitigates abuse from a single host.
+- `node.maxConnections`: the maximum number of peer connections (default: 30). Passive connections from non-trusted peers are rejected once this limit is reached. A peer is considered trusted if its IP appears in `node.passive`, `node.active`, or `fastForward` (the IPs from all three are added to the trust list). Active connections bypass this check entirely: active connections to peers configured in `node.active` are bounded only by the size of the `node.active` list, while active connections to peers discovered via the discovery protocol are driven by `minConnections` and `minActiveConnections` (see below).
+- `node.minConnections`: the desired minimum total number of peer connections, counting both active and passive (default: 8). When the total is below this value, the node initiates active connections to discovered peers to close the gap.
+- `node.minActiveConnections`: the desired minimum number of active connections to discovered peers (default: 3). The node will keep initiating active connections to discovered peers until this threshold is met, even if the total connection count has already reached or exceeded `minConnections`.
+- `node.maxConnectionsWithSameIp`: the maximum number of connections allowed from the same IP address (default: 2). It mitigates abuse from a single IP.
 
 ```
 node {

--- a/docs/using_javatron/connecting_to_tron.md
+++ b/docs/using_javatron/connecting_to_tron.md
@@ -1,6 +1,6 @@
 # Connect to the TRON Network
 
-The TRON network is mainly divided into four enironments:
+The TRON network is mainly divided into four environments:
 
 - **Mainnet**
 - **Nile Testnet**
@@ -198,7 +198,7 @@ genesis.block = {
       voteCount = 100000000
     }
   ]
-  timestamp = "0" #2017-8-26 12:00:00
+  timestamp = "0" # Genesis block timestamp, milli seconds
   parentHash = "0xe58f33f9baf9305dc6f82b9f1934ea8f0ade2defb951258d50167028c780351f"
 }
 ```
@@ -262,14 +262,24 @@ In some cases (e.g., local testing or a fixed private network), you may disable 
 ## Node Connection
 
 ### Number of Node Connections
-`node.maxConnections`  defines the maximum number of peer connections (default: 30). Higher values improve network joining and broadcasting efficiency but require more bandwidth and resources: 
+The number of peer connections is controlled by the following parameters. They are usually tuned together:
+
+- `node.maxConnections`: the maximum number of peer connections (default: 30). Inbound connections from non-trusted peers are rejected once this limit is reached. A peer is considered trusted if its IP appears in `node.passive`, `node.active`, or `fastForward` (the IPs from all three are added to the trust list). Outbound connections bypass this check entirely: outbound to peers configured in `node.active` is bounded only by the size of the `node.active` list, while outbound to peers discovered via the discovery protocol is driven by `minConnections` and `minActiveConnections` (see below).
+- `node.minConnections`: the desired minimum total number of peer connections, counting both inbound and outbound (default: 8). When the total is below this value, the node initiates outbound connections to discovered peers to close the gap.
+- `node.minActiveConnections`: the desired minimum number of outbound connections to discovered peers (default: 3). The node will keep initiating outbound connections to discovered peers until this threshold is met, even if the total connection count has already reached or exceeded `minConnections`.
+- `node.maxConnectionsWithSameIp`: the maximum number of connections allowed from the same IP address (default: 2). It mitigates abuse from a single host.
+
 ```
 node {
   ...
-  maxConnections = 30           # max connections
+  maxConnections = 30
+  minConnections = 8
+  minActiveConnections = 3
+  maxConnectionsWithSameIp = 2
   ...
 }
 ```
+Note: `minConnections` must not exceed `maxConnections`, and `minActiveConnections` must not exceed `minConnections`; otherwise the node will automatically clamp them at startup.
 
 
 
@@ -354,7 +364,7 @@ Generate block 79336 success, trxs:0, pendingCount: 0, rePushCount: 0, postponed
 Use the HTTP API:
 
 ```
-$ curl http://127.0.0.1:16887/wallet/getnodeinfo
+$ curl http://127.0.0.1:8090/wallet/getnodeinfo
 ```
 Example response：
 ```
@@ -388,7 +398,7 @@ Example response：
 ### Verify Node Synchronization
 Compare your local block height with [TRONSCAN](https://tronscan.org/) ：
 ```
-curl http://127.0.0.1:16887/wallet/getnowblock
+curl http://127.0.0.1:8090/wallet/getnowblock
 ```
 If the heights match, synchronization is normal.
 

--- a/docs/using_javatron/private_network.md
+++ b/docs/using_javatron/private_network.md
@@ -135,7 +135,7 @@ The operational steps for deploying a private network node are fundamentally the
          ```
          var TronWeb = require('tronweb');
          var tronWeb = new TronWeb({
-             fullHost: 'http://localhost:16887',
+             fullHost: 'http://localhost:8090',
              privateKey: 'privateKey'
          })
 


### PR DESCRIPTION
## Summary

Reviewed `docs/using_javatron/connecting_to_tron.md` against the libp2p source and java-tron `config.conf`, and corrected several inaccuracies.

- **Expanded the Number of Node Connections section** to cover `minConnections`, `minActiveConnections`, and `maxConnectionsWithSameIp` (previously only `maxConnections` was documented). The new wording reflects how the parameters actually interact in `libp2p`'s `ConnPoolService` and `ChannelManager`: trust-peer handling, that outbound bypasses `maxConnections`, and the startup clamping done in `TronNetService`.
- **Corrected the HTTP port in API examples** from `16887` to `8090`, the actual default `node.http.fullNodePort` in `config.conf`. Applied in both `connecting_to_tron.md` and `private_network.md`.
- **Genesis block timestamp comment** now matches the wording in java-tron's `config.conf` (`# Genesis block timestamp, milli seconds`), removing the misleading `#2017-8-26 12:00:00` annotation next to a literal `"0"`.
- **Fixed typo** `enironments` → `environments`.

## Test plan

- [ ] Render the doc locally and confirm the new bullet list and code block under "Number of Node Connections" display correctly.
- [ ] Verify the two `curl` examples (`getnodeinfo`, `getnowblock`) work against a local java-tron fullnode using port 8090.