### PR TITLE
Sync system-contracts doc with java-tron proto

### DIFF
--- a/docs/mechanism-algorithm/multi-signatures.md
+++ b/docs/mechanism-algorithm/multi-signatures.md
@@ -105,61 +105,7 @@ message AccountPermissionUpdateContract {
 
 ### 5. Contract Type Enumeration: `ContractType`
 
-```
-enum ContractType {
-  AccountCreateContract = 0;
-  ...
-  AccountPermissionUpdateContract = 46;
-}
-```
-
-The detailed information of `ContractType` is as follows (including Proto Message, Actuator, status, and business Triggered):
-
-| # | ContractType | Proto Message | Actuator | Status | Business Triggered |
-|---|---|---|---|---|---|
-| 0 | AccountCreateContract | AccountContract.AccountCreateContract | CreateAccountActuator | ✅ Enabled | Create an on-chain account |
-| 1 | TransferContract | BalanceContract.TransferContract | TransferActuator | ✅ Enabled | TRX Transfer |
-| 2 | TransferAssetContract | AssetIssueContractOuterClass.TransferAssetContract | TransferAssetActuator | ✅ Enabled | TRC10 Token Transfer |
-| 3 | VoteAssetContract | | | 🚫 Disabled (Actuator not implemented) | |
-| 4 | VoteWitnessContract | WitnessContract.VoteWitnessContract | VoteWitnessActuator | ✅ Enabled | Vote for SRs using account's TronPower; refresh voting records (takes effect at next maintenance) |
-| 5 | WitnessCreateContract | WitnessContract.WitnessCreateContract | WitnessCreateActuator | ✅ Enabled | Apply to become a Super Representative (SR) candidate; write to witness store |
-| 6 | AssetIssueContract | AssetIssueContractOuterClass.AssetIssueContract | AssetIssueActuator | ✅ Enabled | Issue TRC10 tokens; freeze balance during recruitment period according to ICO rules |
-| 8 | WitnessUpdateContract | WitnessContract.WitnessUpdateContract | WitnessUpdateActuator | ✅ Enabled | Update the official website URL of an SR |
-| 9 | ParticipateAssetIssueContract | AssetIssueContractOuterClass.ParticipateAssetIssueContract | ParticipateAssetIssueActuator | ✅ Enabled | Subscribe to TRC10 tokens with TRX during the ICO period |
-| 10 | AccountUpdateContract | AccountContract.AccountUpdateContract | UpdateAccountActuator | ✅ Enabled | Modify account name (subject to AllowUpdateAccountName constraint) |
-| 11 | FreezeBalanceContract | BalanceContract.FreezeBalanceContract | FreezeBalanceActuator | 🚫 Disabled (rejected by chain after `supportUnfreezeDelay` is enabled) | Stake 1.0: Freeze TRX to gain Bandwidth/Energy; can be delegated to others |
-| 12 | UnfreezeBalanceContract | BalanceContract.UnfreezeBalanceContract | UnfreezeBalanceActuator | ✅ Enabled | Stake 1.0: Unfreeze TRX after expiration; release resources and clear votes |
-| 13 | WithdrawBalanceContract | BalanceContract.WithdrawBalanceContract | WithdrawBalanceActuator | ✅ Enabled | Withdraw SR block/voting rewards to account balance |
-| 14 | UnfreezeAssetContract | AssetIssueContractOuterClass.UnfreezeAssetContract | UnfreezeAssetActuator | ✅ Enabled | Issuer unfreezes TRC10 token shares frozen during ICO |
-| 15 | UpdateAssetContract | AssetIssueContractOuterClass.UpdateAssetContract | UpdateAssetActuator | ✅ Enabled | Update TRC10 token description / url / free bandwidth quota |
-| 16 | ProposalCreateContract | ProposalContract.ProposalCreateContract | ProposalCreateActuator | ✅ Enabled | SR creates an on-chain parameter proposal; written to ProposalStore for voting |
-| 17 | ProposalApproveContract | ProposalContract.ProposalApproveContract | ProposalApproveActuator | ✅ Enabled | SR approves or cancels a vote on a proposal |
-| 18 | ProposalDeleteContract | ProposalContract.ProposalDeleteContract | ProposalDeleteActuator | ✅ Enabled | Proposal creator withdraws their own created proposal |
-| 19 | SetAccountIdContract | AccountContract.SetAccountIdContract | SetAccountIdActuator | ✅ Enabled | Set a unique account_id for the account (can only be set once) |
-| 20 | CustomContract | | | 🚫 Disabled (Actuator not implemented) | |
-| 30 | CreateSmartContract | SmartContractOuterClass.CreateSmartContract | VMActuator | ✅ Enabled | Deploy a smart contract |
-| 31 | TriggerSmartContract | SmartContractOuterClass.TriggerSmartContract | VMActuator | ✅ Enabled | Call/Trigger a smart contract |
-| 32 | GetContract | | | 🚫 Disabled (Actuator not implemented) | |
-| 33 | UpdateSettingContract | SmartContractOuterClass.UpdateSettingContract | UpdateSettingContractActuator | ✅ Enabled | Contract owner modifies `consume_user_resource_percent` (percentage of energy borne by the user) |
-| 41 | ExchangeCreateContract | ExchangeContract.ExchangeCreateContract | ExchangeCreateActuator | ✅ Enabled | Create a Bancor exchange pair; inject initial liquidity for two assets |
-| 42 | ExchangeInjectContract | ExchangeContract.ExchangeInjectContract | ExchangeInjectActuator | ✅ Enabled | Inject liquidity into an existing exchange pair; deduct assets based on Bancor algorithm |
-| 43 | ExchangeWithdrawContract | ExchangeContract.ExchangeWithdrawContract | ExchangeWithdrawActuator | ✅ Enabled | Exchange pair creator redeems both assets from the pair proportionally |
-| 44 | ExchangeTransactionContract | ExchangeContract.ExchangeTransactionContract | ExchangeTransactionActuator | 🚫 Disabled | Asset exchange via Bancor exchange pair |
-| 45 | UpdateEnergyLimitContract | SmartContractOuterClass.UpdateEnergyLimitContract | UpdateEnergyLimitContractActuator | ✅ Enabled | Contract owner updates `origin_energy_limit` (max energy consumption owner is willing to pay per call) |
-| 46 | AccountPermissionUpdateContract | AccountContract.AccountPermissionUpdateContract | AccountPermissionUpdateActuator | ✅ Enabled | Update account permissions: owner/witness/active |
-| 48 | ClearABIContract | SmartContractOuterClass.ClearABIContract | ClearABIContractActuator | ✅ Enabled | Contract owner clears contract ABI |
-| 49 | UpdateBrokerageContract | StorageContract.UpdateBrokerageContract | UpdateBrokerageActuator | ✅ Enabled | SR adjusts the brokerage ratio (0-100%) for voters |
-| 51 | ShieldedTransferContract | ShieldContract.ShieldedTransferContract | ShieldedTransferActuator | 🚫 Disabled (`getAllowShieldedTransaction` not enabled) | ZK-SNARK anonymous transfer (transparent in + shielded spend/receive + transparent out) |
-| 52 | MarketSellAssetContract | MarketContract.MarketSellAssetContract | MarketSellAssetActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Place a limit sell order on the built-in order book (sell/buy two assets + price) |
-| 53 | MarketCancelOrderContract | MarketContract.MarketCancelOrderContract | MarketCancelOrderActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Cancel own unexecuted market order; refund remaining assets |
-| 54 | FreezeBalanceV2Contract | BalanceContract.FreezeBalanceV2Contract | FreezeBalanceV2Actuator | ✅ Enabled | Stake 2.0: Freeze TRX to gain Bandwidth/Energy; decouples resources from TronPower |
-| 55 | UnfreezeBalanceV2Contract | BalanceContract.UnfreezeBalanceV2Contract | UnfreezeBalanceV2Actuator | ✅ Enabled | Stake 2.0: Initiate unstaking; enters unfreeze waiting period |
-| 56 | WithdrawExpireUnfreezeContract | BalanceContract.WithdrawExpireUnfreezeContract | WithdrawExpireUnfreezeActuator | ✅ Enabled | Withdraw unfrozen TRX that has passed the waiting period to account balance |
-| 57 | DelegateResourceContract | BalanceContract.DelegateResourceContract | DelegateResourceActuator | ✅ Enabled | Stake 2.0: Delegate own staked Bandwidth/Energy to other addresses (lock-up period optional) |
-| 58 | UnDelegateResourceContract | BalanceContract.UnDelegateResourceContract | UnDelegateResourceActuator | ✅ Enabled | Stake 2.0: Reclaim previously delegated resources from others |
-| 59 | CancelAllUnfreezeV2Contract | BalanceContract.CancelAllUnfreezeV2Contract | CancelAllUnfreezeV2Actuator | ✅ Enabled | Cancel all pending Stake 2.0 unfreezing requests; remaining shares are re-staked |
-
-Active permissions configure which `ContractType` can be executed through the `operations` field. For details on how to calculate the value of `operations`, please see [Operations Value Calculation Example](#2-operations-value-calculation-example).
+Active permissions configure which `ContractType` can be executed through the `operations` field. The full list of `ContractType` enum values together with their Proto Message, Actuator, status, and business behaviors is maintained in [System Contracts — ContractType Overview](./system-contracts.md#contracttype-overview). For details on how to calculate the value of `operations` from these enum values, please see [Operations Value Calculation Example](#2-operations-value-calculation-example).
 
 ## Explanation of Each Permission Type
 

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -11,10 +11,10 @@ Every system contract is identified by a `ContractType` enum value defined in [`
 | 1 | TransferContract | BalanceContract.TransferContract | TransferActuator | ✅ Enabled | TRX Transfer |
 | 2 | TransferAssetContract | AssetIssueContractOuterClass.TransferAssetContract | TransferAssetActuator | ✅ Enabled | TRC-10 token transfer |
 | 3 | VoteAssetContract | | | 🚫 Disabled (Actuator not implemented) | |
-| 4 | VoteWitnessContract | WitnessContract.VoteWitnessContract | VoteWitnessActuator | ✅ Enabled | Vote for SRs using account's TronPower; refresh voting records (takes effect at next maintenance) |
-| 5 | WitnessCreateContract | WitnessContract.WitnessCreateContract | WitnessCreateActuator | ✅ Enabled | Apply to become a Super Representative (SR) candidate; write to witness store |
+| 4 | VoteWitnessContract | WitnessContract.VoteWitnessContract | VoteWitnessActuator | ✅ Enabled | Vote for Witnesses using account's TronPower; refresh voting records (takes effect at next maintenance) |
+| 5 | WitnessCreateContract | WitnessContract.WitnessCreateContract | WitnessCreateActuator | ✅ Enabled | Apply to become a Witness; write to witness store |
 | 6 | AssetIssueContract | AssetIssueContractOuterClass.AssetIssueContract | AssetIssueActuator | ✅ Enabled | Issue TRC-10 tokens; freeze balance during recruitment period according to ICO rules |
-| 8 | WitnessUpdateContract | WitnessContract.WitnessUpdateContract | WitnessUpdateActuator | ✅ Enabled | Update the official website URL of an SR |
+| 8 | WitnessUpdateContract | WitnessContract.WitnessUpdateContract | WitnessUpdateActuator | ✅ Enabled | Update the official website URL of a Witness |
 | 9 | ParticipateAssetIssueContract | AssetIssueContractOuterClass.ParticipateAssetIssueContract | ParticipateAssetIssueActuator | ✅ Enabled | Participate in a TRC-10 token issuance with TRX during the ICO period |
 | 10 | AccountUpdateContract | AccountContract.AccountUpdateContract | UpdateAccountActuator | ✅ Enabled | Modify account name (subject to AllowUpdateAccountName constraint) |
 | 11 | FreezeBalanceContract | BalanceContract.FreezeBalanceContract | FreezeBalanceActuator | 🚫 Disabled (rejected by chain after `supportUnfreezeDelay` is enabled) | Stake 1.0: Freeze TRX to gain Bandwidth/Energy; can be delegated to others |
@@ -22,8 +22,8 @@ Every system contract is identified by a `ContractType` enum value defined in [`
 | 13 | WithdrawBalanceContract | BalanceContract.WithdrawBalanceContract | WithdrawBalanceActuator | ✅ Enabled | Withdraw SR block/voting rewards to account balance |
 | 14 | UnfreezeAssetContract | AssetIssueContractOuterClass.UnfreezeAssetContract | UnfreezeAssetActuator | ✅ Enabled | Issuer unfreezes TRC-10 token shares frozen during ICO |
 | 15 | UpdateAssetContract | AssetIssueContractOuterClass.UpdateAssetContract | UpdateAssetActuator | ✅ Enabled | Update TRC-10 token description / url / free bandwidth quota |
-| 16 | ProposalCreateContract | ProposalContract.ProposalCreateContract | ProposalCreateActuator | ✅ Enabled | SR creates an on-chain parameter proposal; written to ProposalStore for voting |
-| 17 | ProposalApproveContract | ProposalContract.ProposalApproveContract | ProposalApproveActuator | ✅ Enabled | SR approves or cancels a vote on a proposal |
+| 16 | ProposalCreateContract | ProposalContract.ProposalCreateContract | ProposalCreateActuator | ✅ Enabled | Witness creates an on-chain parameter proposal; written to ProposalStore for voting |
+| 17 | ProposalApproveContract | ProposalContract.ProposalApproveContract | ProposalApproveActuator | ✅ Enabled | Witness approves or cancels a vote on a proposal |
 | 18 | ProposalDeleteContract | ProposalContract.ProposalDeleteContract | ProposalDeleteActuator | ✅ Enabled | Proposal creator withdraws their own created proposal |
 | 19 | SetAccountIdContract | AccountContract.SetAccountIdContract | SetAccountIdActuator | ✅ Enabled | Set a unique account_id for the account (can only be set once) |
 | 20 | CustomContract | | | 🚫 Disabled (Actuator not implemented) | |
@@ -33,12 +33,12 @@ Every system contract is identified by a `ContractType` enum value defined in [`
 | 33 | UpdateSettingContract | SmartContractOuterClass.UpdateSettingContract | UpdateSettingContractActuator | ✅ Enabled | Contract owner modifies `consume_user_resource_percent` (percentage of energy borne by the user) |
 | 41 | ExchangeCreateContract | ExchangeContract.ExchangeCreateContract | ExchangeCreateActuator | ✅ Enabled | Create a Bancor exchange pair; inject initial liquidity for two assets |
 | 42 | ExchangeInjectContract | ExchangeContract.ExchangeInjectContract | ExchangeInjectActuator | ✅ Enabled | Inject liquidity into an existing exchange pair; deduct assets based on Bancor algorithm |
-| 43 | ExchangeWithdrawContract | ExchangeContract.ExchangeWithdrawContract | ExchangeWithdrawActuator | ✅ Enabled | Exchange pair creator redeems both assets from the pair proportionally |
+| 43 | ExchangeWithdrawContract | ExchangeContract.ExchangeWithdrawContract | ExchangeWithdrawActuator | ✅ Enabled | Exchange pair creator withdraws both assets from the pair proportionally |
 | 44 | ExchangeTransactionContract | ExchangeContract.ExchangeTransactionContract | ExchangeTransactionActuator | 🚫 Disabled | Asset exchange via Bancor exchange pair |
 | 45 | UpdateEnergyLimitContract | SmartContractOuterClass.UpdateEnergyLimitContract | UpdateEnergyLimitContractActuator | ✅ Enabled | Contract owner updates `origin_energy_limit` (max energy consumption owner is willing to pay per call) |
 | 46 | AccountPermissionUpdateContract | AccountContract.AccountPermissionUpdateContract | AccountPermissionUpdateActuator | ✅ Enabled | Update account permissions: owner/witness/active |
 | 48 | ClearABIContract | SmartContractOuterClass.ClearABIContract | ClearABIContractActuator | ✅ Enabled | Contract owner clears contract ABI |
-| 49 | UpdateBrokerageContract | StorageContract.UpdateBrokerageContract | UpdateBrokerageActuator | ✅ Enabled | SR adjusts the brokerage ratio (0-100%) for voters |
+| 49 | UpdateBrokerageContract | StorageContract.UpdateBrokerageContract | UpdateBrokerageActuator | ✅ Enabled | Witness adjusts the brokerage ratio (0-100%) for voters |
 | 51 | ShieldedTransferContract | ShieldContract.ShieldedTransferContract | ShieldedTransferActuator | 🚫 Disabled (`getAllowShieldedTransaction` not enabled) | ZK-SNARK anonymous transfer (transparent in + shielded spend/receive + transparent out) |
 | 52 | MarketSellAssetContract | MarketContract.MarketSellAssetContract | MarketSellAssetActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Place a limit sell order on the built-in order book (sell/buy two assets + price) |
 | 53 | MarketCancelOrderContract | MarketContract.MarketCancelOrderContract | MarketCancelOrderActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Cancel own unexecuted market order; refund remaining assets |
@@ -106,7 +106,7 @@ The protobuf message definition and field-level documentation of each contract a
 ```
 
 - `owner_address`: The address of the account casting votes for Witnesses.
-- `vote_address`: The SR or candidate's address.
+- `vote_address`: The Witness address.
 - `vote_count`: The votes number.
 - `support`: Constant true, not used.
 
@@ -377,7 +377,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the account creating the exchange.
+- `owner_address`: The address of the account creating the exchange pair.
 - `first_token_id`: First token id.
 - `first_token_balance`: First token balance.
 - `second_token_id`: Second token id.
@@ -408,7 +408,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the account withdrawing liquidity.
+- `owner_address`: The address of the account withdrawing liquidity (must be the pair's creator).
 - `exchange_id`: The token pair id.
 - `token_id`: The token id to withdraw.
 - `quant`: The token amount to withdraw.
@@ -455,7 +455,7 @@ The protobuf message definition and field-level documentation of each contract a
 
 - `owner_address`: The address of the account whose permissions will be updated.
 - `owner`: The owner permission of the account. Cannot be empty.
-- `witness`: The witness permission. Required for SR (witness) accounts; must be empty for non-witness accounts.
+- `witness`: The witness permission. Required for Witness accounts; must be empty for non-Witness accounts.
 - `actives`: The list of active permissions. Cannot be empty; at most 8 entries.
 
 For more details, see [Account Permission Management](./multi-signatures.md).
@@ -480,7 +480,7 @@ For more details, see [Account Permission Management](./multi-signatures.md).
 ```
 
 - `owner_address`: The address of the Witness adjusting its brokerage ratio.
-- `brokerage`: Commission rate, from 0 to 100,1 mean 1%.
+- `brokerage`: Brokerage ratio, from 0 to 100, 1 means 1%.
 
 ## ShieldedTransferContract
 ```

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -11,10 +11,10 @@ Every system contract is identified by a `ContractType` enum value defined in [`
 | 1 | TransferContract | BalanceContract.TransferContract | TransferActuator | ✅ Enabled | TRX Transfer |
 | 2 | TransferAssetContract | AssetIssueContractOuterClass.TransferAssetContract | TransferAssetActuator | ✅ Enabled | TRC-10 token transfer |
 | 3 | VoteAssetContract | | | 🚫 Disabled (Actuator not implemented) | |
-| 4 | VoteWitnessContract | WitnessContract.VoteWitnessContract | VoteWitnessActuator | ✅ Enabled | Vote for Witnesses using account's TronPower; refresh voting records (takes effect at next maintenance) |
-| 5 | WitnessCreateContract | WitnessContract.WitnessCreateContract | WitnessCreateActuator | ✅ Enabled | Apply to become a Witness; write to witness store |
+| 4 | VoteWitnessContract | WitnessContract.VoteWitnessContract | VoteWitnessActuator | ✅ Enabled | Vote for SRs using account's TronPower; refresh voting records (takes effect at next maintenance) |
+| 5 | WitnessCreateContract | WitnessContract.WitnessCreateContract | WitnessCreateActuator | ✅ Enabled | Apply to become a SR |
 | 6 | AssetIssueContract | AssetIssueContractOuterClass.AssetIssueContract | AssetIssueActuator | ✅ Enabled | Issue TRC-10 tokens; freeze balance during recruitment period according to ICO rules |
-| 8 | WitnessUpdateContract | WitnessContract.WitnessUpdateContract | WitnessUpdateActuator | ✅ Enabled | Update the official website URL of a Witness |
+| 8 | WitnessUpdateContract | WitnessContract.WitnessUpdateContract | WitnessUpdateActuator | ✅ Enabled | Update the official website URL of a SR |
 | 9 | ParticipateAssetIssueContract | AssetIssueContractOuterClass.ParticipateAssetIssueContract | ParticipateAssetIssueActuator | ✅ Enabled | Participate in a TRC-10 token issuance with TRX during the ICO period |
 | 10 | AccountUpdateContract | AccountContract.AccountUpdateContract | UpdateAccountActuator | ✅ Enabled | Modify account name (subject to AllowUpdateAccountName constraint) |
 | 11 | FreezeBalanceContract | BalanceContract.FreezeBalanceContract | FreezeBalanceActuator | 🚫 Disabled (rejected by chain after `supportUnfreezeDelay` is enabled) | Stake 1.0: Freeze TRX to gain Bandwidth/Energy; can be delegated to others |
@@ -105,8 +105,8 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the account casting votes for Witnesses.
-- `vote_address`: The Witness address.
+- `owner_address`: The address of the account casting votes for SRs.
+- `vote_address`: The SR address.
 - `vote_count`: The votes number.
 - `support`: Constant true, not used.
 
@@ -118,8 +118,8 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the account applying to become a Witness.
-- `url`: The website url of the witness.
+- `owner_address`: The address of the account applying to become a SR.
+- `url`: The website url of the SR.
 
 ## AssetIssueContract
 ```
@@ -177,8 +177,8 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the Witness updating its URL.
-- `update_url`: The website url of the witness.
+- `owner_address`: The address of the SR updating its URL.
+- `update_url`: The website url of the SR.
 
 ## ParticipateAssetIssueContract
 ```
@@ -455,7 +455,7 @@ The protobuf message definition and field-level documentation of each contract a
 
 - `owner_address`: The address of the account whose permissions will be updated.
 - `owner`: The owner permission of the account. Cannot be empty.
-- `witness`: The witness permission. Required for Witness accounts; must be empty for non-Witness accounts.
+- `witness`: The witness permission. Required for SRs; must be empty for non-SRs.
 - `actives`: The list of active permissions. Cannot be empty; at most 8 entries.
 
 For more details, see [Account Permission Management](./multi-signatures.md).
@@ -479,7 +479,7 @@ For more details, see [Account Permission Management](./multi-signatures.md).
     }
 ```
 
-- `owner_address`: The address of the Witness adjusting its brokerage ratio.
+- `owner_address`: The address of the SR adjusting its brokerage ratio.
 - `brokerage`: Brokerage ratio, from 0 to 100, 1 means 1%.
 
 ## ShieldedTransferContract

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -134,10 +134,11 @@ The protobuf message definition and field-level documentation of each contract a
       int64 total_supply = 4;
       repeated FrozenSupply frozen_supply = 5;
       int32 trx_num = 6;
+      int32 precision = 7;
       int32 num = 8;
       int64 start_time = 9;
       int64 end_time = 10;
-      int64 order = 11; // the order of tokens of the same name
+      int64 order = 11; // useless
       int32 vote_score = 16;
       bytes description = 20;
       bytes url = 21;
@@ -145,6 +146,7 @@ The protobuf message definition and field-level documentation of each contract a
       int64 public_free_asset_net_limit = 23;
       int64 public_free_asset_net_usage = 24;
       int64 public_latest_free_net_time = 25;
+      string id = 41;
     }
 ```
 
@@ -165,6 +167,7 @@ The protobuf message definition and field-level documentation of each contract a
 - `public_free_asset_net_limit`: The free bandwidth limit all the accounts can use.
 - `public_free_asset_net_usage`: The free bandwidth usage of all the accounts.
 - `public_latest_free_net_time`: The latest bandwidth consumption time of token transfer.
+- `id`: The unique token ID, generated sequentially by the system at issuance (incrementing from 1000001).
 
 ## WitnessUpdateContract
 ```
@@ -226,7 +229,7 @@ The protobuf message definition and field-level documentation of each contract a
     message UnfreezeBalanceContract {
       bytes owner_address = 1;
       ResourceCode resource = 10;
-      bytes receiver_address = 13;
+      bytes receiver_address = 15;
     }
 ```
 
@@ -612,6 +615,7 @@ message ReceiveDescription {
       int64 balance = 3;
       bytes receiver_address = 4;
       bool  lock = 5;
+      int64 lock_period = 6;
       }
 ```
 
@@ -619,7 +623,8 @@ message ReceiveDescription {
 * `resource`： Resource type
 * `balance`： Amount of TRX staked for resources to be delegated, unit is sun
 * `receiver_address`：Resource receiver address
-* `lock`：Indicates whether the delegation is locked. If `true`, the delegated resources cannot be undelegated for 3 days. If the owner delegates the same resource type to the same address with a lock before the initial lock expires, the 3-day lock timer is reset.
+* `lock`：Whether to lock this delegation.
+* `lock_period`：The lock duration when `lock=true`, in blocks (3 seconds per block). User-supplied values are only accepted after the `MAX_DELEGATE_LOCK_PERIOD` proposal takes effect; in that case `0` means use the default of 86400 blocks (3 days), and the upper bound is determined by the chain parameter `getMaxDelegateLockPeriod`. Before the proposal takes effect this field is ignored and the lock duration is fixed at 86400 blocks.
    
    
 ## UnDelegateResourceContract

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -105,7 +105,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the voter account.
+- `owner_address`: The address of the account casting votes for Witnesses.
 - `vote_address`: The SR or candidate's address.
 - `vote_count`: The votes number.
 - `support`: Constant true, not used.
@@ -177,7 +177,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The Witness account address.
+- `owner_address`: The address of the Witness updating its URL.
 - `update_url`: The website url of the witness.
 
 ## ParticipateAssetIssueContract
@@ -424,7 +424,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the trading account.
+- `owner_address`: The address of the account exchanging assets via the pair.
 - `exchange_id`: The token pair id.
 - `token_id`: The token id to sell.
 - `quant`: The token amount to sell.
@@ -479,7 +479,7 @@ For more details, see [Account Permission Management](./multi-signatures.md).
     }
 ```
 
-- `owner_address`: The Witness account address.
+- `owner_address`: The address of the Witness adjusting its brokerage ratio.
 - `brokerage`: Commission rate, from 0 to 100,1 mean 1%.
 
 ## ShieldedTransferContract
@@ -638,7 +638,7 @@ message ReceiveDescription {
       }
 ```
 
-* `owner_address`: The address of the account canceling the delegation.
+* `owner_address`: The address of the account reclaiming previously delegated resources.
 * `resource`： Resource type
 * `balance`：undelegated TRX, unit is sun
 * `receiver_address`：Resource receiver address

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -20,25 +20,25 @@ Every system contract is identified by a `ContractType` enum value defined in [`
 | 11 | FreezeBalanceContract | BalanceContract.FreezeBalanceContract | FreezeBalanceActuator | 🚫 Disabled (rejected by chain after `supportUnfreezeDelay` is enabled) | Stake 1.0: Freeze TRX to gain Bandwidth/Energy; can be delegated to others |
 | 12 | UnfreezeBalanceContract | BalanceContract.UnfreezeBalanceContract | UnfreezeBalanceActuator | ✅ Enabled | Stake 1.0: Unfreeze TRX after expiration; release resources and clear votes |
 | 13 | WithdrawBalanceContract | BalanceContract.WithdrawBalanceContract | WithdrawBalanceActuator | ✅ Enabled | Withdraw SR block/voting rewards to account balance |
-| 14 | UnfreezeAssetContract | AssetIssueContractOuterClass.UnfreezeAssetContract | UnfreezeAssetActuator | ✅ Enabled | Issuer unfreezes TRC-10 token shares frozen during ICO |
+| 14 | UnfreezeAssetContract | AssetIssueContractOuterClass.UnfreezeAssetContract | UnfreezeAssetActuator | ✅ Enabled | Unfreeze TRC-10 token shares frozen during ICO |
 | 15 | UpdateAssetContract | AssetIssueContractOuterClass.UpdateAssetContract | UpdateAssetActuator | ✅ Enabled | Update TRC-10 token description / url / free bandwidth quota |
-| 16 | ProposalCreateContract | ProposalContract.ProposalCreateContract | ProposalCreateActuator | ✅ Enabled | Witness creates an on-chain parameter proposal; written to ProposalStore for voting |
-| 17 | ProposalApproveContract | ProposalContract.ProposalApproveContract | ProposalApproveActuator | ✅ Enabled | Witness approves or cancels a vote on a proposal |
-| 18 | ProposalDeleteContract | ProposalContract.ProposalDeleteContract | ProposalDeleteActuator | ✅ Enabled | Proposal creator withdraws their own created proposal |
+| 16 | ProposalCreateContract | ProposalContract.ProposalCreateContract | ProposalCreateActuator | ✅ Enabled | Create an on-chain parameter proposal; written to ProposalStore for voting |
+| 17 | ProposalApproveContract | ProposalContract.ProposalApproveContract | ProposalApproveActuator | ✅ Enabled | Approve or cancel a vote on a proposal |
+| 18 | ProposalDeleteContract | ProposalContract.ProposalDeleteContract | ProposalDeleteActuator | ✅ Enabled | Withdraw the created proposal |
 | 19 | SetAccountIdContract | AccountContract.SetAccountIdContract | SetAccountIdActuator | ✅ Enabled | Set a unique account_id for the account (can only be set once) |
 | 20 | CustomContract | | | 🚫 Disabled (Actuator not implemented) | |
 | 30 | CreateSmartContract | SmartContractOuterClass.CreateSmartContract | VMActuator | ✅ Enabled | Deploy a smart contract |
 | 31 | TriggerSmartContract | SmartContractOuterClass.TriggerSmartContract | VMActuator | ✅ Enabled | Call/Trigger a smart contract |
 | 32 | GetContract | | | 🚫 Disabled (Actuator not implemented) | |
-| 33 | UpdateSettingContract | SmartContractOuterClass.UpdateSettingContract | UpdateSettingContractActuator | ✅ Enabled | Contract owner modifies `consume_user_resource_percent` (percentage of energy borne by the user) |
+| 33 | UpdateSettingContract | SmartContractOuterClass.UpdateSettingContract | UpdateSettingContractActuator | ✅ Enabled | Modify `consume_user_resource_percent` (percentage of energy borne by the user) |
 | 41 | ExchangeCreateContract | ExchangeContract.ExchangeCreateContract | ExchangeCreateActuator | ✅ Enabled | Create a Bancor exchange pair; inject initial liquidity for two assets |
 | 42 | ExchangeInjectContract | ExchangeContract.ExchangeInjectContract | ExchangeInjectActuator | ✅ Enabled | Inject liquidity into an existing exchange pair; deduct assets based on Bancor algorithm |
-| 43 | ExchangeWithdrawContract | ExchangeContract.ExchangeWithdrawContract | ExchangeWithdrawActuator | ✅ Enabled | Exchange pair creator withdraws both assets from the pair proportionally |
+| 43 | ExchangeWithdrawContract | ExchangeContract.ExchangeWithdrawContract | ExchangeWithdrawActuator | ✅ Enabled | Withdraw both assets from the pair proportionally |
 | 44 | ExchangeTransactionContract | ExchangeContract.ExchangeTransactionContract | ExchangeTransactionActuator | 🚫 Disabled | Asset exchange via Bancor exchange pair |
-| 45 | UpdateEnergyLimitContract | SmartContractOuterClass.UpdateEnergyLimitContract | UpdateEnergyLimitContractActuator | ✅ Enabled | Contract owner updates `origin_energy_limit` (max energy consumption owner is willing to pay per call) |
+| 45 | UpdateEnergyLimitContract | SmartContractOuterClass.UpdateEnergyLimitContract | UpdateEnergyLimitContractActuator | ✅ Enabled | Update `origin_energy_limit` (max energy willing to pay per contract call) |
 | 46 | AccountPermissionUpdateContract | AccountContract.AccountPermissionUpdateContract | AccountPermissionUpdateActuator | ✅ Enabled | Update account permissions: owner/witness/active |
-| 48 | ClearABIContract | SmartContractOuterClass.ClearABIContract | ClearABIContractActuator | ✅ Enabled | Contract owner clears contract ABI |
-| 49 | UpdateBrokerageContract | StorageContract.UpdateBrokerageContract | UpdateBrokerageActuator | ✅ Enabled | Witness adjusts the brokerage ratio (0-100%) for voters |
+| 48 | ClearABIContract | SmartContractOuterClass.ClearABIContract | ClearABIContractActuator | ✅ Enabled | Clear contract ABI |
+| 49 | UpdateBrokerageContract | StorageContract.UpdateBrokerageContract | UpdateBrokerageActuator | ✅ Enabled | Adjust the brokerage ratio (0-100%) for voters |
 | 51 | ShieldedTransferContract | ShieldContract.ShieldedTransferContract | ShieldedTransferActuator | 🚫 Disabled (`getAllowShieldedTransaction` not enabled) | ZK-SNARK anonymous transfer (transparent in + shielded spend/receive + transparent out) |
 | 52 | MarketSellAssetContract | MarketContract.MarketSellAssetContract | MarketSellAssetActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Place a limit sell order on the built-in order book (sell/buy two assets + price) |
 | 53 | MarketCancelOrderContract | MarketContract.MarketCancelOrderContract | MarketCancelOrderActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Cancel own unexecuted market order; refund remaining assets |
@@ -393,7 +393,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The address of the account injecting liquidity.
+- `owner_address`: The address of the account injecting liquidity (must be the pair's creator).
 - `exchange_id`: The token pair id.
 - `token_id`: The token id to inject.
 - `quant`: The token amount to inject.

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -1,6 +1,56 @@
 # System Contracts
 The TRON network supports many different types of transactions, such as TRX transfers, TRC10 transfers , smart contract creation and triggering and TRX staking. To create different types of transactions, you need to call different APIs. For example, the transaction type for smart contract deployment is `CreateSmartContract`, which requires calling the `wallet/deploycontractAPI`.The transaction type of stake TRX is `FreezeBalanceV2Contract`, which requires calling the ` wallet/freezebalancev2API`. We collectively refer to the implementation of these different transaction types as system contracts.
 
+## ContractType Overview
+
+Every system contract is identified by a `ContractType` enum value defined in [`Tron.proto`](https://github.com/tronprotocol/java-tron/blob/master/protocol/src/main/protos/core/Tron.proto). The table below lists each `ContractType` together with its Proto Message, Actuator, current status, and the business it triggers.
+
+| # | ContractType | Proto Message | Actuator | Status | Business Triggered |
+|---|---|---|---|---|---|
+| 0 | AccountCreateContract | AccountContract.AccountCreateContract | CreateAccountActuator | ✅ Enabled | Create an on-chain account |
+| 1 | TransferContract | BalanceContract.TransferContract | TransferActuator | ✅ Enabled | TRX Transfer |
+| 2 | TransferAssetContract | AssetIssueContractOuterClass.TransferAssetContract | TransferAssetActuator | ✅ Enabled | TRC10 Token Transfer |
+| 3 | VoteAssetContract | | | 🚫 Disabled (Actuator not implemented) | |
+| 4 | VoteWitnessContract | WitnessContract.VoteWitnessContract | VoteWitnessActuator | ✅ Enabled | Vote for SRs using account's TronPower; refresh voting records (takes effect at next maintenance) |
+| 5 | WitnessCreateContract | WitnessContract.WitnessCreateContract | WitnessCreateActuator | ✅ Enabled | Apply to become a Super Representative (SR) candidate; write to witness store |
+| 6 | AssetIssueContract | AssetIssueContractOuterClass.AssetIssueContract | AssetIssueActuator | ✅ Enabled | Issue TRC10 tokens; freeze balance during recruitment period according to ICO rules |
+| 8 | WitnessUpdateContract | WitnessContract.WitnessUpdateContract | WitnessUpdateActuator | ✅ Enabled | Update the official website URL of an SR |
+| 9 | ParticipateAssetIssueContract | AssetIssueContractOuterClass.ParticipateAssetIssueContract | ParticipateAssetIssueActuator | ✅ Enabled | Subscribe to TRC10 tokens with TRX during the ICO period |
+| 10 | AccountUpdateContract | AccountContract.AccountUpdateContract | UpdateAccountActuator | ✅ Enabled | Modify account name (subject to AllowUpdateAccountName constraint) |
+| 11 | FreezeBalanceContract | BalanceContract.FreezeBalanceContract | FreezeBalanceActuator | 🚫 Disabled (rejected by chain after `supportUnfreezeDelay` is enabled) | Stake 1.0: Freeze TRX to gain Bandwidth/Energy; can be delegated to others |
+| 12 | UnfreezeBalanceContract | BalanceContract.UnfreezeBalanceContract | UnfreezeBalanceActuator | ✅ Enabled | Stake 1.0: Unfreeze TRX after expiration; release resources and clear votes |
+| 13 | WithdrawBalanceContract | BalanceContract.WithdrawBalanceContract | WithdrawBalanceActuator | ✅ Enabled | Withdraw SR block/voting rewards to account balance |
+| 14 | UnfreezeAssetContract | AssetIssueContractOuterClass.UnfreezeAssetContract | UnfreezeAssetActuator | ✅ Enabled | Issuer unfreezes TRC10 token shares frozen during ICO |
+| 15 | UpdateAssetContract | AssetIssueContractOuterClass.UpdateAssetContract | UpdateAssetActuator | ✅ Enabled | Update TRC10 token description / url / free bandwidth quota |
+| 16 | ProposalCreateContract | ProposalContract.ProposalCreateContract | ProposalCreateActuator | ✅ Enabled | SR creates an on-chain parameter proposal; written to ProposalStore for voting |
+| 17 | ProposalApproveContract | ProposalContract.ProposalApproveContract | ProposalApproveActuator | ✅ Enabled | SR approves or cancels a vote on a proposal |
+| 18 | ProposalDeleteContract | ProposalContract.ProposalDeleteContract | ProposalDeleteActuator | ✅ Enabled | Proposal creator withdraws their own created proposal |
+| 19 | SetAccountIdContract | AccountContract.SetAccountIdContract | SetAccountIdActuator | ✅ Enabled | Set a unique account_id for the account (can only be set once) |
+| 20 | CustomContract | | | 🚫 Disabled (Actuator not implemented) | |
+| 30 | CreateSmartContract | SmartContractOuterClass.CreateSmartContract | VMActuator | ✅ Enabled | Deploy a smart contract |
+| 31 | TriggerSmartContract | SmartContractOuterClass.TriggerSmartContract | VMActuator | ✅ Enabled | Call/Trigger a smart contract |
+| 32 | GetContract | | | 🚫 Disabled (Actuator not implemented) | |
+| 33 | UpdateSettingContract | SmartContractOuterClass.UpdateSettingContract | UpdateSettingContractActuator | ✅ Enabled | Contract owner modifies `consume_user_resource_percent` (percentage of energy borne by the user) |
+| 41 | ExchangeCreateContract | ExchangeContract.ExchangeCreateContract | ExchangeCreateActuator | ✅ Enabled | Create a Bancor exchange pair; inject initial liquidity for two assets |
+| 42 | ExchangeInjectContract | ExchangeContract.ExchangeInjectContract | ExchangeInjectActuator | ✅ Enabled | Inject liquidity into an existing exchange pair; deduct assets based on Bancor algorithm |
+| 43 | ExchangeWithdrawContract | ExchangeContract.ExchangeWithdrawContract | ExchangeWithdrawActuator | ✅ Enabled | Exchange pair creator redeems both assets from the pair proportionally |
+| 44 | ExchangeTransactionContract | ExchangeContract.ExchangeTransactionContract | ExchangeTransactionActuator | 🚫 Disabled | Asset exchange via Bancor exchange pair |
+| 45 | UpdateEnergyLimitContract | SmartContractOuterClass.UpdateEnergyLimitContract | UpdateEnergyLimitContractActuator | ✅ Enabled | Contract owner updates `origin_energy_limit` (max energy consumption owner is willing to pay per call) |
+| 46 | AccountPermissionUpdateContract | AccountContract.AccountPermissionUpdateContract | AccountPermissionUpdateActuator | ✅ Enabled | Update account permissions: owner/witness/active |
+| 48 | ClearABIContract | SmartContractOuterClass.ClearABIContract | ClearABIContractActuator | ✅ Enabled | Contract owner clears contract ABI |
+| 49 | UpdateBrokerageContract | StorageContract.UpdateBrokerageContract | UpdateBrokerageActuator | ✅ Enabled | SR adjusts the brokerage ratio (0-100%) for voters |
+| 51 | ShieldedTransferContract | ShieldContract.ShieldedTransferContract | ShieldedTransferActuator | 🚫 Disabled (`getAllowShieldedTransaction` not enabled) | ZK-SNARK anonymous transfer (transparent in + shielded spend/receive + transparent out) |
+| 52 | MarketSellAssetContract | MarketContract.MarketSellAssetContract | MarketSellAssetActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Place a limit sell order on the built-in order book (sell/buy two assets + price) |
+| 53 | MarketCancelOrderContract | MarketContract.MarketCancelOrderContract | MarketCancelOrderActuator | 🚫 Disabled (`getAllowMarketTransaction` not enabled) | Cancel own unexecuted market order; refund remaining assets |
+| 54 | FreezeBalanceV2Contract | BalanceContract.FreezeBalanceV2Contract | FreezeBalanceV2Actuator | ✅ Enabled | Stake 2.0: Freeze TRX to gain Bandwidth/Energy; decouples resources from TronPower |
+| 55 | UnfreezeBalanceV2Contract | BalanceContract.UnfreezeBalanceV2Contract | UnfreezeBalanceV2Actuator | ✅ Enabled | Stake 2.0: Initiate unstaking; enters unfreeze waiting period |
+| 56 | WithdrawExpireUnfreezeContract | BalanceContract.WithdrawExpireUnfreezeContract | WithdrawExpireUnfreezeActuator | ✅ Enabled | Withdraw unfrozen TRX that has passed the waiting period to account balance |
+| 57 | DelegateResourceContract | BalanceContract.DelegateResourceContract | DelegateResourceActuator | ✅ Enabled | Stake 2.0: Delegate own staked Bandwidth/Energy to other addresses (lock-up period optional) |
+| 58 | UnDelegateResourceContract | BalanceContract.UnDelegateResourceContract | UnDelegateResourceActuator | ✅ Enabled | Stake 2.0: Reclaim previously delegated resources from others |
+| 59 | CancelAllUnfreezeV2Contract | BalanceContract.CancelAllUnfreezeV2Contract | CancelAllUnfreezeV2Actuator | ✅ Enabled | Cancel all pending Stake 2.0 unfreezing requests; remaining shares are re-staked |
+
+The protobuf message definition and field-level documentation of each contract are listed in the sections below.
+
 ## AccountCreateContract
 ```
     message AccountCreateContract {
@@ -139,7 +189,7 @@ The TRON network supports many different types of transactions, such as TRX tran
 
 - `owner_address`: The owner of the current account.
 - `to_address`: The token owner's address.
-- `account_name`: The token id.
+- `asset_name`: The token id.
 - `amount`: The amount of token to purchase.
 
 ## AccountUpdateContract
@@ -377,6 +427,58 @@ The TRON network supports many different types of transactions, such as TRX tran
 - `quant`: The token amount to sell.
 - `expected`: The expected token amount to buy, if the calculated actual token amount that can be bought is less than this value, the transaction will fail.
 
+## UpdateEnergyLimitContract
+```
+    message UpdateEnergyLimitContract {
+      bytes owner_address = 1;
+      bytes contract_address = 2;
+      int64 origin_energy_limit = 3;
+    }
+```
+
+- `owner_address`: The owner of the current account.
+- `contract_address`: The contract address.
+- `origin_energy_limit`: The target energy limit to change.
+
+## AccountPermissionUpdateContract
+```
+    message AccountPermissionUpdateContract {
+      bytes owner_address = 1;
+      Permission owner = 2;             //Empty is invalidate
+      Permission witness = 3;           //Can be empty
+      repeated Permission actives = 4;  //Empty is invalidate
+    }
+```
+
+- `owner_address`: The owner of the current account.
+- `owner`: The owner permission of the account. Cannot be empty.
+- `witness`: The witness permission. Only valid for SR (witness) accounts; can be empty for non-witness accounts.
+- `actives`: The list of active permissions. Cannot be empty.
+
+For more details, see [Account Permission Management](./multi-signatures.md).
+
+## ClearABIContract
+```
+    message ClearABIContract {
+      bytes owner_address = 1;
+      bytes contract_address = 2;
+    }
+```
+
+- `owner_address`: The owner of the current account.
+- `account_address`: The target contract address to clear ABI.
+
+## UpdateBrokerageContract
+```
+    message UpdateBrokerageContract {
+      bytes owner_address = 1;
+      int32 brokerage = 2;
+    }
+```
+
+- `owner_address`: The owner of the current account.
+- `brokerage`: Commission rate, from 0 to 100,1 mean 1%.
+
 ## ShieldedTransferContract
 ```
     message ShieldedTransferContract {
@@ -434,44 +536,33 @@ message ReceiveDescription {
 - `c_out`: part of note ciphertext, encryption of the receiver's public key and ephemeral private key.
 - `zkproof`: zero-knowledge proof of the receiver's note.
 
-## Account Permission Management
-
-[Account Permission Management](./multi-signatures.md)
-
-## ClearABIContract
+## MarketSellAssetContract
 ```
-    message ClearABIContract {
+    message MarketSellAssetContract {
       bytes owner_address = 1;
-      bytes contract_address = 2;
+      bytes sell_token_id = 2;
+      int64 sell_token_quantity = 3;
+      bytes buy_token_id = 4;
+      int64 buy_token_quantity = 5; // min to receive
     }
 ```
 
 - `owner_address`: The owner of the current account.
-- `account_address`: The target contract address to clear ABI.
+- `sell_token_id`: The id of the token to sell.
+- `sell_token_quantity`: The amount of the token to sell.
+- `buy_token_id`: The id of the token to buy.
+- `buy_token_quantity`: The minimum amount of the buy token to receive. If the actual amount obtained when matching is less than this value, the order will be placed on the order book waiting to be matched at a better price.
 
-## UpdateBrokerageContract
+## MarketCancelOrderContract
 ```
-    message UpdateBrokerageContract {
+    message MarketCancelOrderContract {
       bytes owner_address = 1;
-      int32 brokerage = 2;
+      bytes order_id = 2;
     }
 ```
 
 - `owner_address`: The owner of the current account.
-- `brokerage`: Commission rate, from 0 to 100,1 mean 1%.
-
-## UpdateEnergyLimitContract
-```
-    message UpdateEnergyLimitContract {
-      bytes owner_address = 1;
-      bytes contract_address = 2;
-      int64 origin_energy_limit = 3;
-    }
-```
-
-- `owner_address`: The owner of the current account.
-- `contract_address`: The contract address.
-- `origin_energy_limit`: The target energy limit to change.
+- `order_id`: The id of the market order to cancel.
 
 ## FreezeBalanceV2Contract
 
@@ -546,11 +637,17 @@ message ReceiveDescription {
 * `resource`： Resource type
 * `balance`：undelegated TRX, unit is sun
 * `receiver_address`：Resource receiver address
-   
 
 
+## CancelAllUnfreezeV2Contract
 
+```protobuf
+      message CancelAllUnfreezeV2Contract {
+        bytes owner_address = 1;
+      }
+```
 
+* `owner_address`：The owner's address
 
 
 

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -204,7 +204,7 @@ The protobuf message definition and field-level documentation of each contract a
 - `owner_address`: The owner of the current account.
 - `account_name`: Account name.
 
-## (Deprecated)FreezeBalanceContract
+## FreezeBalanceContract
 ```
     message FreezeBalanceContract {
       bytes owner_address = 1;
@@ -452,8 +452,8 @@ The protobuf message definition and field-level documentation of each contract a
 
 - `owner_address`: The owner of the current account.
 - `owner`: The owner permission of the account. Cannot be empty.
-- `witness`: The witness permission. Only valid for SR (witness) accounts; can be empty for non-witness accounts.
-- `actives`: The list of active permissions. Cannot be empty.
+- `witness`: The witness permission. Required for SR (witness) accounts; must be empty for non-witness accounts.
+- `actives`: The list of active permissions. Cannot be empty; at most 8 entries.
 
 For more details, see [Account Permission Management](./multi-signatures.md).
 
@@ -466,7 +466,7 @@ For more details, see [Account Permission Management](./multi-signatures.md).
 ```
 
 - `owner_address`: The owner of the current account.
-- `account_address`: The target contract address to clear ABI.
+- `contract_address`: The target contract address to clear ABI.
 
 ## UpdateBrokerageContract
 ```

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -207,23 +207,6 @@ The protobuf message definition and field-level documentation of each contract a
 - `owner_address`: The address of the account to update.
 - `account_name`: Account name.
 
-## FreezeBalanceContract
-```
-    message FreezeBalanceContract {
-      bytes owner_address = 1;
-      int64 frozen_balance = 2;
-      int64 frozen_duration = 3;
-      ResourceCode resource = 10;
-      bytes receiver_address = 15;
-    }
-```
-
-- `owner_address`: The address of the account staking TRX.
-- `frozen_balance`: The amount of TRX to stake.
-- `frozen_duration`: The stake duration.
-- `resource`: The type of resource get by staking TRX.
-- `receiver_address`: The account address to receive resource.
-
 ## UnfreezeBalanceContract
 ```
     message UnfreezeBalanceContract {
@@ -413,23 +396,6 @@ The protobuf message definition and field-level documentation of each contract a
 - `token_id`: The token id to withdraw.
 - `quant`: The token amount to withdraw.
 
-## ExchangeTransactionContract
-```
-    message ExchangeTransactionContract {
-      bytes owner_address = 1;
-      int64 exchange_id = 2;
-      bytes token_id = 3;
-      int64 quant = 4;
-      int64 expected = 5;
-    }
-```
-
-- `owner_address`: The address of the account exchanging assets via the pair.
-- `exchange_id`: The token pair id.
-- `token_id`: The token id to sell.
-- `quant`: The token amount to sell.
-- `expected`: The expected token amount to buy, if the calculated actual token amount that can be bought is less than this value, the transaction will fail.
-
 ## UpdateEnergyLimitContract
 ```
     message UpdateEnergyLimitContract {
@@ -481,91 +447,6 @@ For more details, see [Account Permission Management](./multi-signatures.md).
 
 - `owner_address`: The address of the SR adjusting its brokerage ratio.
 - `brokerage`: Brokerage ratio, from 0 to 100, 1 means 1%.
-
-## ShieldedTransferContract
-```
-    message ShieldedTransferContract {
-      bytes transparent_from_address = 1;
-      int64 from_amount = 2;
-      repeated SpendDescription spend_description = 3;
-      repeated ReceiveDescription receive_description = 4;
-      bytes binding_signature = 5;
-      bytes transparent_to_address = 6;
-      int64 to_amount = 7;
-    }
-```
-
-- `transparent_from_address`: The transparent address of the sender.
-- `from_amount`: The amount to send.
-- `spend_description`: Shielded spend information.
-- `receive_description`: Shielded receive information.
-- `binding_signature`: The binding signature.
-- `transparent_to_address`: The transparent address of the receiver.
-- `to_amount`: The amount to receive.
-
-```
-message SpendDescription {
-  bytes value_commitment = 1;
-  bytes anchor = 2;
-  bytes nullifier = 3;
-  bytes rk = 4;
-  bytes zkproof = 5;
-  bytes spend_authority_signature = 6;
-}
-```
-
-- `value_commitment`: _value commitment_ of spender's transfer amount.
-- `anchor`: root of the note commitment Merkle tree at some block.
-- `nullifier`: _nullifier_ of spender's note, to prevent double-spent.
-- `rk`: public key, to verify spender's _Spend Authorization Signature_.
-- `zkproof`: zero-knowledge proof of spender's note, prove that this note exists and could be spent.
-- `spend_authority_signature`: the spender's _Spend Authorization Signature_.
-
-```
-message ReceiveDescription {
-  bytes value_commitment = 1;
-  bytes note_commitment = 2;
-  bytes epk = 3;
-  bytes c_enc = 4;
-  bytes c_out = 5;
-  bytes zkproof = 6;
-}
-```
-
-- `value_commitment`: _value commitment_ of receiver's transfer amount.
-- `note_commitment`: commitment of the receiver's note.
-- `epk`: ephemeral public key, in order to generate note's decryption key.
-- `c_enc`: part of note ciphertext, encryption of diversifier, receiver's transfer amount, rcm, and memo.
-- `c_out`: part of note ciphertext, encryption of the receiver's public key and ephemeral private key.
-- `zkproof`: zero-knowledge proof of the receiver's note.
-
-## MarketSellAssetContract
-```
-    message MarketSellAssetContract {
-      bytes owner_address = 1;
-      bytes sell_token_id = 2;
-      int64 sell_token_quantity = 3;
-      bytes buy_token_id = 4;
-      int64 buy_token_quantity = 5; // min to receive
-    }
-```
-
-- `owner_address`: The address of the account placing the order.
-- `sell_token_id`: The id of the token to sell.
-- `sell_token_quantity`: The amount of the token to sell.
-- `buy_token_id`: The id of the token to buy.
-- `buy_token_quantity`: The minimum amount of the buy token to receive. If the actual amount obtained when matching is less than this value, the order will be placed on the order book waiting to be matched at a better price.
-
-## MarketCancelOrderContract
-```
-    message MarketCancelOrderContract {
-      bytes owner_address = 1;
-      bytes order_id = 2;
-    }
-```
-
-- `owner_address`: The address of the account that placed the order.
-- `order_id`: The id of the market order to cancel.
 
 ## FreezeBalanceV2Contract
 

--- a/docs/mechanism-algorithm/system-contracts.md
+++ b/docs/mechanism-algorithm/system-contracts.md
@@ -1,5 +1,5 @@
 # System Contracts
-The TRON network supports many different types of transactions, such as TRX transfers, TRC10 transfers , smart contract creation and triggering and TRX staking. To create different types of transactions, you need to call different APIs. For example, the transaction type for smart contract deployment is `CreateSmartContract`, which requires calling the `wallet/deploycontractAPI`.The transaction type of stake TRX is `FreezeBalanceV2Contract`, which requires calling the ` wallet/freezebalancev2API`. We collectively refer to the implementation of these different transaction types as system contracts.
+The TRON network supports many different types of transactions, such as TRX transfers, TRC-10 transfers, smart contract creation and triggering and TRX staking. To create different types of transactions, you need to call different APIs. For example, the transaction type for smart contract deployment is `CreateSmartContract`, which requires calling the `wallet/deploycontractAPI`.The transaction type of stake TRX is `FreezeBalanceV2Contract`, which requires calling the ` wallet/freezebalancev2API`. We collectively refer to the implementation of these different transaction types as system contracts.
 
 ## ContractType Overview
 
@@ -9,19 +9,19 @@ Every system contract is identified by a `ContractType` enum value defined in [`
 |---|---|---|---|---|---|
 | 0 | AccountCreateContract | AccountContract.AccountCreateContract | CreateAccountActuator | ✅ Enabled | Create an on-chain account |
 | 1 | TransferContract | BalanceContract.TransferContract | TransferActuator | ✅ Enabled | TRX Transfer |
-| 2 | TransferAssetContract | AssetIssueContractOuterClass.TransferAssetContract | TransferAssetActuator | ✅ Enabled | TRC10 Token Transfer |
+| 2 | TransferAssetContract | AssetIssueContractOuterClass.TransferAssetContract | TransferAssetActuator | ✅ Enabled | TRC-10 token transfer |
 | 3 | VoteAssetContract | | | 🚫 Disabled (Actuator not implemented) | |
 | 4 | VoteWitnessContract | WitnessContract.VoteWitnessContract | VoteWitnessActuator | ✅ Enabled | Vote for SRs using account's TronPower; refresh voting records (takes effect at next maintenance) |
 | 5 | WitnessCreateContract | WitnessContract.WitnessCreateContract | WitnessCreateActuator | ✅ Enabled | Apply to become a Super Representative (SR) candidate; write to witness store |
-| 6 | AssetIssueContract | AssetIssueContractOuterClass.AssetIssueContract | AssetIssueActuator | ✅ Enabled | Issue TRC10 tokens; freeze balance during recruitment period according to ICO rules |
+| 6 | AssetIssueContract | AssetIssueContractOuterClass.AssetIssueContract | AssetIssueActuator | ✅ Enabled | Issue TRC-10 tokens; freeze balance during recruitment period according to ICO rules |
 | 8 | WitnessUpdateContract | WitnessContract.WitnessUpdateContract | WitnessUpdateActuator | ✅ Enabled | Update the official website URL of an SR |
-| 9 | ParticipateAssetIssueContract | AssetIssueContractOuterClass.ParticipateAssetIssueContract | ParticipateAssetIssueActuator | ✅ Enabled | Subscribe to TRC10 tokens with TRX during the ICO period |
+| 9 | ParticipateAssetIssueContract | AssetIssueContractOuterClass.ParticipateAssetIssueContract | ParticipateAssetIssueActuator | ✅ Enabled | Participate in a TRC-10 token issuance with TRX during the ICO period |
 | 10 | AccountUpdateContract | AccountContract.AccountUpdateContract | UpdateAccountActuator | ✅ Enabled | Modify account name (subject to AllowUpdateAccountName constraint) |
 | 11 | FreezeBalanceContract | BalanceContract.FreezeBalanceContract | FreezeBalanceActuator | 🚫 Disabled (rejected by chain after `supportUnfreezeDelay` is enabled) | Stake 1.0: Freeze TRX to gain Bandwidth/Energy; can be delegated to others |
 | 12 | UnfreezeBalanceContract | BalanceContract.UnfreezeBalanceContract | UnfreezeBalanceActuator | ✅ Enabled | Stake 1.0: Unfreeze TRX after expiration; release resources and clear votes |
 | 13 | WithdrawBalanceContract | BalanceContract.WithdrawBalanceContract | WithdrawBalanceActuator | ✅ Enabled | Withdraw SR block/voting rewards to account balance |
-| 14 | UnfreezeAssetContract | AssetIssueContractOuterClass.UnfreezeAssetContract | UnfreezeAssetActuator | ✅ Enabled | Issuer unfreezes TRC10 token shares frozen during ICO |
-| 15 | UpdateAssetContract | AssetIssueContractOuterClass.UpdateAssetContract | UpdateAssetActuator | ✅ Enabled | Update TRC10 token description / url / free bandwidth quota |
+| 14 | UnfreezeAssetContract | AssetIssueContractOuterClass.UnfreezeAssetContract | UnfreezeAssetActuator | ✅ Enabled | Issuer unfreezes TRC-10 token shares frozen during ICO |
+| 15 | UpdateAssetContract | AssetIssueContractOuterClass.UpdateAssetContract | UpdateAssetActuator | ✅ Enabled | Update TRC-10 token description / url / free bandwidth quota |
 | 16 | ProposalCreateContract | ProposalContract.ProposalCreateContract | ProposalCreateActuator | ✅ Enabled | SR creates an on-chain parameter proposal; written to ProposalStore for voting |
 | 17 | ProposalApproveContract | ProposalContract.ProposalApproveContract | ProposalApproveActuator | ✅ Enabled | SR approves or cancels a vote on a proposal |
 | 18 | ProposalDeleteContract | ProposalContract.ProposalDeleteContract | ProposalDeleteActuator | ✅ Enabled | Proposal creator withdraws their own created proposal |
@@ -60,7 +60,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account creating the new account.
 - `account_address`: The target address to create.
 - `type`: Account type. 0 means normal account; 1 means the Genesis account; 2 means smart contract account.
 
@@ -73,7 +73,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account sending TRX.
 - `to_address`: The target address to receive the transfer.
 - `amount`: The amount of TRX to transfer.
 
@@ -88,7 +88,7 @@ The protobuf message definition and field-level documentation of each contract a
 ```
 
 - `asset_name`: The TRC-10 token ID to transfer.
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account sending the TRC-10 token.
 - `to_address`: The target address to receive the transfer.
 - `amount`: The amount of token to transfer.
 
@@ -105,7 +105,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the voter account.
 - `vote_address`: The SR or candidate's address.
 - `vote_count`: The votes number.
 - `support`: Constant true, not used.
@@ -118,7 +118,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account applying to become a Witness.
 - `url`: The website url of the witness.
 
 ## AssetIssueContract
@@ -150,7 +150,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account issuing the TRC-10 token.
 - `name`: The token name to issue.
 - `abbr`: The abbreviation of the token name.
 - `total_supply`: The amount of token to issue.
@@ -177,7 +177,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The Witness account address.
 - `update_url`: The website url of the witness.
 
 ## ParticipateAssetIssueContract
@@ -190,7 +190,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account participating in the asset issue.
 - `to_address`: The token owner's address.
 - `asset_name`: The token id.
 - `amount`: The amount of token to purchase.
@@ -204,7 +204,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account to update.
 - `account_name`: Account name.
 
 ## FreezeBalanceContract
@@ -218,7 +218,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account staking TRX.
 - `frozen_balance`: The amount of TRX to stake.
 - `frozen_duration`: The stake duration.
 - `resource`: The type of resource get by staking TRX.
@@ -233,7 +233,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account unstaking TRX.
 - `resource`: The type of resource to unfree.
 - `receiver_address`: The account address to receive resource.
 
@@ -244,7 +244,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account withdrawing rewards.
 
 ## UnfreezeAssetContract
 ```
@@ -253,7 +253,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the token issuer.
 
 ## UpdateAssetContract
 ```
@@ -266,7 +266,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the token issuer.
 - `description`: The description of the token.
 - `url`: The website url of the token.
 - `new_limit`: The bandwidth consumption limit of each account when transfers asset.
@@ -280,7 +280,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account creating the proposal.
 - `parameters`: The proposal.
 
 ## ProposalApproveContract
@@ -292,7 +292,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account approving the proposal.
 - `proposal_id`: The proposal id.
 - `is_add_approval`: Whether to approve.
 
@@ -304,7 +304,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account deleting the proposal.
 - `proposal_id`: The proposal id.
 
 ## SetAccountIdContract
@@ -316,7 +316,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account setting the account id.
 - `account_id`: The account id.
 
 ## CreateSmartContract
@@ -329,7 +329,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account deploying the contract.
 - `new_contract`: the smart contract.
 - `call_token_value` : The amount of TRC-10 token to send to the contract when triggers.
 - `token_id` : The id of the TRC-10 token to be sent to the contract.
@@ -346,7 +346,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account calling the contract.
 - `contract_address`: The contract address.
 - `call_value`: The amount of TRX to send to the contract when triggers.
 - `data`: The parameters to trigger the contract.
@@ -362,7 +362,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the contract deployer.
 - `contract_address`: The address of the smart contract.
 - `consume_user_resource_percent`: The percentage of resource consumption ratio.
 
@@ -377,7 +377,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account creating the exchange.
 - `first_token_id`: First token id.
 - `first_token_balance`: First token balance.
 - `second_token_id`: Second token id.
@@ -393,7 +393,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account injecting liquidity.
 - `exchange_id`: The token pair id.
 - `token_id`: The token id to inject.
 - `quant`: The token amount to inject.
@@ -408,7 +408,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account withdrawing liquidity.
 - `exchange_id`: The token pair id.
 - `token_id`: The token id to withdraw.
 - `quant`: The token amount to withdraw.
@@ -424,7 +424,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the trading account.
 - `exchange_id`: The token pair id.
 - `token_id`: The token id to sell.
 - `quant`: The token amount to sell.
@@ -439,7 +439,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the contract deployer.
 - `contract_address`: The contract address.
 - `origin_energy_limit`: The target energy limit to change.
 
@@ -453,7 +453,7 @@ The protobuf message definition and field-level documentation of each contract a
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account whose permissions will be updated.
 - `owner`: The owner permission of the account. Cannot be empty.
 - `witness`: The witness permission. Required for SR (witness) accounts; must be empty for non-witness accounts.
 - `actives`: The list of active permissions. Cannot be empty; at most 8 entries.
@@ -468,7 +468,7 @@ For more details, see [Account Permission Management](./multi-signatures.md).
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the contract deployer.
 - `contract_address`: The target contract address to clear ABI.
 
 ## UpdateBrokerageContract
@@ -479,7 +479,7 @@ For more details, see [Account Permission Management](./multi-signatures.md).
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The Witness account address.
 - `brokerage`: Commission rate, from 0 to 100,1 mean 1%.
 
 ## ShieldedTransferContract
@@ -550,7 +550,7 @@ message ReceiveDescription {
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account placing the order.
 - `sell_token_id`: The id of the token to sell.
 - `sell_token_quantity`: The amount of the token to sell.
 - `buy_token_id`: The id of the token to buy.
@@ -564,7 +564,7 @@ message ReceiveDescription {
     }
 ```
 
-- `owner_address`: The owner of the current account.
+- `owner_address`: The address of the account that placed the order.
 - `order_id`: The id of the market order to cancel.
 
 ## FreezeBalanceV2Contract
@@ -577,7 +577,7 @@ message ReceiveDescription {
       }
 ```
 
-* `owner_address`：The owner's address
+* `owner_address`: The address of the account staking TRX.
 * `frozen_balance`：TRX stake amount, the unit is sun
 * `resource`： Resource type
 
@@ -591,7 +591,7 @@ message ReceiveDescription {
       }
 ```
 
-* `owner_address`：Owner address
+* `owner_address`: The address of the account unstaking TRX.
 * `unfreeze_balance`：The amount of TRX to unstake, in sun
 * `resource`： Resource type
    
@@ -604,7 +604,7 @@ message ReceiveDescription {
       }
 ```
 
-* `owner_address`：The owner's address
+* `owner_address`: The address of the account withdrawing expired unstaked TRX.
    
 ## DelegateResourceContract
 
@@ -619,7 +619,7 @@ message ReceiveDescription {
       }
 ```
 
-* `owner_address`：The owner's address
+* `owner_address`: The address of the resource delegator.
 * `resource`： Resource type
 * `balance`： Amount of TRX staked for resources to be delegated, unit is sun
 * `receiver_address`：Resource receiver address
@@ -638,7 +638,7 @@ message ReceiveDescription {
       }
 ```
 
-* `owner_address`：The owner's address
+* `owner_address`: The address of the account canceling the delegation.
 * `resource`： Resource type
 * `balance`：undelegated TRX, unit is sun
 * `receiver_address`：Resource receiver address
@@ -652,7 +652,7 @@ message ReceiveDescription {
       }
 ```
 
-* `owner_address`：The owner's address
+* `owner_address`: The address of the account canceling all pending Stake 2.0 unfreezing requests.
 
 
 


### PR DESCRIPTION
## Summary

Brings `docs/mechanism-algorithm/system-contracts.md` back in sync with the current `java-tron` source after cross-checking `protocol/src/main/protos/core/Tron.proto`, the per-contract `*.proto` files, and each `*Actuator.java`.

### ContractType overview and missing sections (commit b5784bd)
- Add a **ContractType Overview** table at the top of `system-contracts.md` listing every `ContractType` enum value with its Proto Message, Actuator class, current status, and triggered business; per-contract message definitions stay in the sections below.
- Fill in previously missing per-contract sections: `UpdateEnergyLimitContract`, `AccountPermissionUpdateContract`, `MarketSellAssetContract`, `MarketCancelOrderContract`, `CancelAllUnfreezeV2Contract`.
- Drop the `(Deprecated)` prefix from the `FreezeBalanceContract` heading so it lines up with the other disabled contracts (status is already conveyed in the overview table).
- Replace the duplicated `ContractType` table in `multi-signatures.md` with a link to the new overview section to keep a single source of truth.

### Field-name and constraint fixes (commit 08f0d49)
- Correct field-name mismatches against the proto:
  - `ParticipateAssetIssueContract`: `account_name` → `asset_name`
  - `ClearABIContract`: `account_address` → `contract_address`
- Tighten `AccountPermissionUpdateContract` field constraints to match `AccountPermissionUpdateActuator.validate()`:
  - `witness` is **required** for SR accounts and **must be empty** for non-witness accounts
  - `actives` is capped at **8 entries**

### Proto definition sync (commit 63177d2)
- `UnfreezeBalanceContract.receiver_address`: field number corrected from `13` to `15`.
- `AssetIssueContract`: add missing `int32 precision = 7;` and `string id = 41;` fields with matching descriptions; update the stale `order` inline comment to `// useless` (no business effect in current source).
- `DelegateResourceContract`: add the missing `int64 lock_period = 6;` field with a description covering its semantics and the `MAX_DELEGATE_LOCK_PERIOD` proposal gating; correct the `lock` field description (the original "lock for 3 days" is no longer accurate).

### Terminology and field-description polish (commit 89e65f0)
- **Per-contract `owner_address` descriptions.** Replace the generic placeholder with contract-specific semantics, cross-checked against the corresponding `*Actuator.validate()` in java-tron. For example: `AssetIssueContract.owner_address` → "The address of the account issuing the TRC-10 token."; `UnfreezeAssetContract.owner_address` → "The address of the token issuer." (validated by `accountCapsule.getAssetIssuedName()/getAssetIssuedID()` non-empty checks); `UpdateSettingContract` / `UpdateEnergyLimitContract` / `ClearABIContract` → "The address of the contract deployer." (validated by the `Arrays.equals(ownerAddress, deployedContractOwnerAddress)` check in each actuator). Distinguishes the state-owning account from the signer, which matters under multi-sig.
- **Witness terminology.** Rename `ParticipateAssetIssueContract.owner_address` from "the subscriber account" to "the account participating in the asset issue" to match the proto name. Update the ContractType table entry from `Subscribe` to `Participate`.
- **TRC-10 spelling.** Standardize `TRC10` → `TRC-10` across the ContractType table and prose; fix stray spacing.
- **Token casing.** Lowercase `Token` → `token` in prose (e.g. table cell "TRC-10 token transfer"); proto field names and code blocks remain unchanged.

## Test plan

- [x] `mkdocs serve` / `mkdocs build --strict` renders the overview table and new sections without warnings
- [x] The cross-link from `multi-signatures.md` (`./system-contracts.md#contracttype-overview`) resolves
- [x] Spot-checked each row in the table against `Tron.proto` and the corresponding `*Actuator.java` constructor in java-tron
- [x] Each per-contract `owner_address` description was cross-checked against the corresponding `*Actuator.validate()` in java-tron