### PR TITLE
Align architecture/database.md with current java-tron storage layer and Toolkit behavior

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -45,7 +45,7 @@ dbSettings = {
 ## Migrating from LevelDB to RocksDB on x86_64 Platforms
 To migrate from LevelDB to RocksDB, use the TRON Toolkit `Toolkit.jar`.
 
-> **Note:** The `db convert` subcommand is x86_64-only. On arm64 it prints an "unsupported architecture" message and exits without doing any work, since arm64 builds do not ship the LevelDB native library.
+> **Note:** The `db convert` subcommand is x86_64-only. On arm64 it prints an "unsupported architecture" message and exits without doing any work.
 ### 1. Data Conversion Steps
 ```
 cd java-tron                                   # Source root directory

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -87,7 +87,6 @@ java -jar build/libs/Toolkit.jar db cp output-directory/database /tmp/output-dir
 cd /tmp
 java -jar build/libs/Toolkit.jar db convert output-directory/database output-directory-dst/database
 ```
-> Note:
-The entire data conversion process is expected to take approximately **10 hours**, depending on the data volume and disk performance.
+> **Note:** The entire data conversion process is expected to take approximately **10 hours**, depending on the data volume and disk performance.
 ## About LevelDB
 LevelDB is the default data storage engine for java-tron nodes on x86_64 platforms, suitable for resource-constrained or lightweight deployment scenarios. It has a simple structure and is easy to maintain, but it is less efficient than RocksDB in terms of data compression, backup capabilities, and performance for large-scale nodes.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -26,7 +26,16 @@ storage {
   transHistory.switch = "on"
 }
 ```
+
+Key descriptions:
+
+- `db.sync`: when `true`, the underlying engine waits for each write to be physically flushed to disk before returning — safer against power loss / hard crashes, but noticeably slower. Default `false`, in which case writes are buffered by the OS and recent ones may be lost on a crash. Honored by both LevelDB and RocksDB.
+- `transHistory.switch`: when `"off"`, `TransactionHistoryStore` and `TransactionRetStore` silently drop new writes, so `gettransactioninfobyid` returns empty for any transaction processed while the switch was off. Reads of pre-existing data still work. Default `"on"`.
+
 ### 2. RocksDB Optimization Parameters
+
+The `dbSettings` block applies only when `db.engine = "ROCKSDB"`. Under LevelDB, these values are silently ignored.
+
 RocksDB supports various tuning parameters that can be configured based on the performance of the node server. Below is an example of recommended parameters:
 ```
 dbSettings = {

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -44,17 +44,23 @@ dbSettings = {
 
 ## Migrating from LevelDB to RocksDB on x86_64 Platforms
 To migrate from LevelDB to RocksDB, use the TRON Toolkit `Toolkit.jar`.
+
+> **Note:** The `db convert` subcommand is x86_64-only. On arm64 it prints an "unsupported architecture" message and exits without doing any work, since arm64 builds do not ship the LevelDB native library.
 ### 1. Data Conversion Steps
 ```
 cd java-tron                                   # Source root directory
 ./gradlew build -xtest -xcheck                 # Compile the project
 java -jar build/libs/Toolkit.jar db convert    # Perform data conversion
 ```
-### 2. Optional Parameter Descriptions
-If your node uses a custom data directory, you can include the following parameters when running the conversion script:
+### 2. Positional Arguments
+If your node uses a custom data directory, pass the LevelDB source and RocksDB destination as two positional arguments after `db convert`:
 
-- `src_db_path`: LevelDB database path (default: `output-directory/database`)
-- `dst_db_path`: RocksDB database storage path (default: `output-directory-dst/database`)
+```
+java -jar build/libs/Toolkit.jar db convert <src> <dst>
+```
+
+- `<src>`: LevelDB database path (default: `output-directory/database`)
+- `<dst>`: RocksDB database storage path (default: `output-directory-dst/database`)
 
 For example, if the node is run as follows:
 ```
@@ -85,6 +91,3 @@ java -jar build/libs/Toolkit.jar db convert output-directory/database output-dir
 The entire data conversion process is expected to take approximately **10 hours**, depending on the data volume and disk performance.
 ## About LevelDB
 LevelDB is the default data storage engine for java-tron nodes on x86_64 platforms, suitable for resource-constrained or lightweight deployment scenarios. It has a simple structure and is easy to maintain, but it is less efficient than RocksDB in terms of data compression, backup capabilities, and performance for large-scale nodes.
-
-For a detailed comparison between the two, refer to the documentation:
-📘 [RocksDB vs. LevelDB Comparison](https://github.com/tronprotocol/documentation/blob/master/TRX/Rocksdb_vs_Leveldb.md)


### PR DESCRIPTION
## Summary

Audited `docs/architecture/database.md` against the current java-tron
storage layer and the `Toolkit.jar db` subcommands. Fixes a few
inaccuracies and fills in the gaps a reader naturally hits when
looking at the example `storage { ... }` block.

Notable corrections:

- **`db convert` is x86_64-only**: `DbConvert.java` checks
  `Arch.isArm64()` at the top of `call()` and exits early with an
  "unsupported architecture" message, so it does nothing on arm64.
  Surfaced this as a note at the start of the migration section.
- **Positional, not named, arguments**: section 2 previously
  documented `src_db_path` / `dst_db_path` as if they were CLI flags,
  but `DbConvert.java` declares them as picocli `@Parameters` with
  `index = "0"` / `index = "1"`. Renamed the section to "Positional
  Arguments", switched to `<src>` / `<dst>` placeholders, and added
  the explicit `db convert <src> <dst>` command shape.
- **Dropped stale legacy link**: the trailing
  `Rocksdb_vs_Leveldb.md` link pointed at the legacy
  `tronprotocol/documentation` repo, which is no longer maintained.

Filled-in gaps under the `storage { ... }` example block:

- **`db.sync`**: explained that it controls whether the underlying
  engine waits for each write to be physically flushed to disk
  before returning. Default `false`. Verified that all four call
  sites — `LevelDbDataSourceImpl`, `db2/common/LevelDB`,
  `db2/common/RocksDB`, `TronDatabase` — set
  `WriteOptions.sync(storage.isDbSync())`, so the flag applies to
  both engines (the RocksDB path included).
- **`transHistory.switch`**: explained that when `"off"`,
  `TransactionHistoryStore.put` and `TransactionRetStore.put`
  silently drop new writes (`BooleanUtils.toBoolean(switch)` gate),
  which makes `gettransactioninfobyid` return empty for any
  transaction processed while the switch was off. Reads of
  pre-existing data are not gated. Default `"on"`.
- **`dbSettings` is RocksDB-only**: added a leading sentence to
  "RocksDB Optimization Parameters" noting that the block is only
  consumed by `RocksDbSettings.initCustomSettings` (and from there
  by `RocksDbDataSourceImpl`). The LevelDB code path has its own
  per-db tuning via `storage.properties[*]` with different key
  names (`blockSize`, `writeBufferSize`, `cacheSize`, `maxOpenFiles`,
  `compressionType`) and never reads `dbSettings`.

Formatting:

- Normalized the inline-note prefix to `**Note**:` — the trailing
  10-hours note used the bare `> Note:` form (which also wrapped
  to the next line); now matches the bolded single-line style used
  by the arm64 note added in this PR.

## Test plan

- [x] Verified `Arch.isArm64()` gating in `DbConvert.java`
- [x] Verified the two `@Parameters` indices and default values in
      `DbConvert.java`
- [x] Verified `db.sync` consumers across `LevelDbDataSourceImpl`,
      `db2/common/LevelDB`, `db2/common/RocksDB`, `TronDatabase`
- [x] Verified `transHistory.switch` gates `put()` in
      `TransactionHistoryStore` and `TransactionRetStore`, and that
      `Wallet.getTransactionInfoById` reads from both
- [x] Verified `dbSettings` only flows into `RocksDbSettings` and
      `RocksDbDataSourceImpl`; LevelDB path uses
      `StorageUtils.getOptionsByDbName` / `Storage.newDefaultDbOptions`
      with separate key names
- [x] Visual review of the rendered page