### PR TITLE
Align metrics doc with java-tron source and metric_monitor of tron-docker

### DIFF
--- a/docs/using_javatron/installing_javatron.md
+++ b/docs/using_javatron/installing_javatron.md
@@ -93,7 +93,7 @@ uname -m
       ```
     * After compilation is complete, the `FullNode.jar` file will be generated in the `java-tron/build/libs/` directory.
 
-## Starting a java-tron Full Node
+## Starting a java-tron Full Node { #starting-a-java-tron-node }
 A full node acts as a gateway to the TRON network, exposing comprehensive interfaces via HTTP and RPC APIs. Through these endpoints, clients may execute asset transfers, deploy smart contracts, and invoke on-chain logic. It must join a TRON network to participate in the network's consensus and transaction processing.
 
 ### Network Types

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -1,5 +1,5 @@
 # java-tron Node Metrics Monitoring
-Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes expose metrics in the Prometheus exposition format on a `/metrics` endpoint, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node and scrape metric data from this endpoint. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
+Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes expose metrics in the Prometheus exposition format on a `/metrics` endpoint, allowing node operators to monitor node health more conveniently. For the meaning of each exposed metric, see the [All Metrics section](https://github.com/tronprotocol/tron-docker/blob/main/metric_monitor/README.md#all-metrics) of the tron-docker metric_monitor README. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node and scrape metric data from this endpoint. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
 
 ## Configure java-tron
 To use Prometheus for monitoring, you must first enable Prometheus metric monitoring and set the HTTP port in your node's configuration file. Locate the `node.metrics` block in `config.conf` and set `prometheus.enable` to `true`:
@@ -115,15 +115,13 @@ The deployment process of the Grafana visualization tool is as follows:
 
 4. Import Dashboard
 
-    Grafana's dashboard needs to be configured. For the convenience of java-tron node deployers, the TRON community provides a comprehensive dashboard configuration file [java-tron-template_rev1.json](https://grafana.com/grafana/dashboards/16567), which you can download from the Grafana Dashboards library and then import into Grafana.
+    For the convenience of java-tron node deployers, the TRON community provides a set of pre-configured Grafana dashboards. Refer to the [Import dashboard section](https://github.com/tronprotocol/tron-docker/blob/main/metric_monitor/README.md#import-dashboard) of the tron-docker metric_monitor README to import them into Grafana.
 
-    Click the Dashboards icon on the left, then select "+Import", then click "Upload JSON file" to import the downloaded dashboard configuration file:
+    Click the Dashboards icon on the left, then select "+Import", then click "Upload JSON file" to import one of the JSON files mentioned above:
     
     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_import.png)
     
-    Then you can see the following types of monitoring metrics on the dashboard, and monitor the running status of the nodes in real time:
-    
-    ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_dashboard.png)
+    The dashboard will then display the monitoring metrics corresponding to the imported JSON file, allowing you to monitor the running status of the node in real time.
 
 
 

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -14,7 +14,7 @@ node.metrics = {
 ```
 ## Start java-tron node
 
-After updating the configuration, start the node as described in [Starting a FullNode on the TRON main network](installing_javatron.md#starting-a-fullnode-on-the-tron-main-network).
+After updating the configuration, start the node as described in [Starting a java-tron Full Node](installing_javatron.md#starting-a-java-tron-node).
 
 ## Deploy prometheus service
 

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -20,13 +20,15 @@ After updating the configuration, start the node as described in [Starting a jav
 
 [Prometheus](https://prometheus.io/download/) officially provides precompiled binaries and Docker images. You can download them directly from the official website or pull the images from Docker Hub. For more detailed installation and configuration instructions, please refer to the [Prometheus documentation](https://prometheus.io/docs/introduction/overview/). For this guide, we will use Docker for a simple deployment:
 
-1. After installing Docker, enter the following command to pull the Prometheus image:
+1. Install Prometheus
+
+    After installing Docker, enter the following command to pull the Prometheus image:
 
     ```
     $ docker pull prom/prometheus
     ```
 
-2. Download the Prometheus configuration file
+2. Prepare the Prometheus configuration file
 
     The following is a Prometheus configuration file template `prometheus.yaml`:
     ```yaml
@@ -63,7 +65,7 @@ After updating the configuration, start the node as described in [Starting a jav
     ```
     $ docker run --name prometheus \
         -d -p 9090:9090 \
-        -v  /Users/test/deploy/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml \
+        -v /Users/test/deploy/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml \
         prom/prometheus:latest
     ```
 
@@ -86,7 +88,7 @@ The deployment process of the Grafana visualization tool is as follows:
 
 1. Install Grafana
 
-    Please refer to the official documentation to install [Grafana](https://grafana.com/docs/grafana/next/setup-grafana/installation/). This article will adopt the Docker image deployment, and the pulled image version is the open source version:
+    Please refer to the official documentation to install [Grafana](https://grafana.com/docs/grafana/next/setup-grafana/installation/). This article uses the Docker image deployment, pulling the open source image (`grafana-oss`):
     
     ```
     $ docker pull grafana/grafana-oss
@@ -94,26 +96,26 @@ The deployment process of the Grafana visualization tool is as follows:
 
 2. Start Grafana
 
-    You can use the below command to start Grafana:
+    You can use the following command to start Grafana:
     ```
     $ docker run -d --name=grafana -p 3000:3000 grafana/grafana-oss
     ```
 
 3. Log in to the Grafana web UI
 
-    After startup, login the Grafana web UI through `http://localhost:3000/`. The default username and password are both `admin`. After login, change the password according to the prompts, and then you can enter the main interface. Click the settings icon on the left side of the main page and select "Data Sources" to configure Grafana's data sources:
+    After startup, log in to the Grafana web UI at `http://localhost:3000/`. The default username and password are both `admin`. After login, change the password according to the prompts, and then you can enter the main interface. Click the settings icon on the left side of the main page and select "Data Sources" to configure Grafana's data sources:
     
     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_datasource.png)
 
-    Enter the ip and port of the Prometheus service in `URL`:
+    Enter the IP address and port of the Prometheus service in `URL`:
 
     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_prometheus.png)
     
-    Click the "Save & test" at the bottom of the page. Grafana will test the connection, and if successful, a 'Data source is working' notification will appear.
+    Click the "Save & test" button at the bottom of the page. Grafana will test the connection, and if successful, a 'Data source is working' notification will appear.
 
 4. Import Dashboard
 
-    Grafana's dashboard needs to be configured. For the convenience of java-tron node deployers, the TRON community provides a comprehensive dashboard configuration file [java-tron-template_rev1.json](https://grafana.com/grafana/dashboards/16567), which you can download directly and then import into Grafana.
+    Grafana's dashboard needs to be configured. For the convenience of java-tron node deployers, the TRON community provides a comprehensive dashboard configuration file [java-tron-template_rev1.json](https://grafana.com/grafana/dashboards/16567), which you can download from the Grafana Dashboards library and then import into Grafana.
 
     Click the Dashboards icon on the left, then select "+Import", then click "Upload JSON file" to import the downloaded dashboard configuration file:
     

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -1,7 +1,7 @@
 # java-tron Node Metrics Monitoring
-Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes expose a series of metrics endpoints in the Prometheus exposition format, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node, and obtain the indicator data of the node through the node interface. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
+Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes expose a series of metrics endpoints in the Prometheus exposition format, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node, and obtain metric data from the node's metrics endpoint. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
 
-## Configure java-tron 
+## Configure java-tron
 To use Prometheus for monitoring, you must first enable Prometheus metric monitoring and set the HTTP port in your node's configuration file. Locate the `node.metrics` block in `config.conf` and set `prometheus.enable` to `true`:
 
 ```
@@ -12,15 +12,15 @@ node.metrics = {
   }
 }
 ```
-## Start java-tron node
+## Start the java-tron Node
 
 After updating the configuration, start the node as described in [Starting a java-tron Full Node](installing_javatron.md#starting-a-java-tron-node).
 
-## Deploy prometheus service
+## Deploy Prometheus Service
 
-[Prometheus](https://prometheus.io/download/) officially provides precompiled binaries and Docker images. You can download them directly from the official website or pull the images from Docker Hub. For more detailed installation and configuration instructions, Please refer to the [prometheus documentation](https://prometheus.io/docs/introduction/overview/). For this guide, we will use Docker for a simple deployment:
+[Prometheus](https://prometheus.io/download/) officially provides precompiled binaries and Docker images. You can download them directly from the official website or pull the images from Docker Hub. For more detailed installation and configuration instructions, please refer to the [Prometheus documentation](https://prometheus.io/docs/introduction/overview/). For this guide, we will use Docker for a simple deployment:
 
-1. After installing docker, enter the following command to pull the Prometheus image:
+1. After installing Docker, enter the following command to pull the Prometheus image:
 
     ```
     $ docker pull prom/prometheus
@@ -29,7 +29,7 @@ After updating the configuration, start the node as described in [Starting a jav
 2. Download the Prometheus configuration file
 
     The following is a Prometheus configuration file template `prometheus.yaml`:
-    ```
+    ```yaml
     global:
       scrape_interval: 30s
       scrape_timeout: 10s
@@ -58,7 +58,7 @@ After updating the configuration, start the node as described in [Starting a jav
 
 3. Start a Prometheus container
 
-    Start a Prometheus container with the following command and specify to use the user-defined configuration file in the previous step:`/Users/test/deploy/prometheus/prometheus.yaml` 
+    Start a Prometheus container with the following command, mounting the configuration file from the previous step (`/Users/test/deploy/prometheus/prometheus.yaml`):
     
     ```
     $ docker run --name prometheus \
@@ -67,25 +67,26 @@ After updating the configuration, start the node as described in [Starting a jav
         prom/prometheus:latest
     ```
 
-    After the container starts, you can view the running status of the Prometheus service through `http://localhost:9090/`.
-    
+    After the container starts, you can view the running status of the Prometheus service at `http://localhost:9090/`.
+
     Go to "Status" -> "Configuration" to verify that the container is using the correct configuration file:
-    
-     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_config.png)
 
-     Click "Status" -> "Targets" to view the status of each monitored java-tron node:
-     
-     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_targets.png)
-     
-     In the example above, the status of the first endpoint is UP, meaning Prometheus can successfully fetch data from the node. The second endpoint shows DOWN, indicating an error (hover over the error label for details).
+    ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_config.png)
 
-     When the status of the monitored java-tron nodes is normal, you can monitor the indicator data through visualization tools such as Grafana. This article will use Grafana to display the data:
+    Click "Status" -> "Targets" to view the status of each monitored java-tron node:
+
+    ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_targets.png)
+
+    In the example above, the status of the first endpoint is UP, meaning Prometheus can successfully fetch data from the node. The second endpoint shows DOWN, indicating an error (hover over the error label for details).
+
+    When the status of the monitored java-tron nodes is normal, you can monitor the metrics through visualization tools such as Grafana. This article will use Grafana to display the data:
 
 ## Deploy Grafana
 The deployment process of the Grafana visualization tool is as follows:
 
 1. Install Grafana
-    Please refer to the official documentation to install [Grafana](https://grafana.com/docs/grafana/next/setup-grafana/installation/). This article will adopt the docker image deployment, and the pulled image version is the open source version:
+
+    Please refer to the official documentation to install [Grafana](https://grafana.com/docs/grafana/next/setup-grafana/installation/). This article will adopt the Docker image deployment, and the pulled image version is the open source version:
     
     ```
     $ docker pull grafana/grafana-oss
@@ -114,7 +115,7 @@ The deployment process of the Grafana visualization tool is as follows:
 
     Grafana's dashboard needs to be configured. For the convenience of java-tron node deployers, the TRON community provides a comprehensive dashboard configuration file [java-tron-template_rev1.json](https://grafana.com/grafana/dashboards/16567), which you can download directly and then import into Grafana.
 
-     Click the Dashboards icon on the left, then select "+Import", then click "Upload JSON file" to import the downloaded dashboard configuration file:
+    Click the Dashboards icon on the left, then select "+Import", then click "Upload JSON file" to import the downloaded dashboard configuration file:
     
     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_import.png)
     

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -115,13 +115,13 @@ The deployment process of the Grafana visualization tool is as follows:
 
 4. Import Dashboard
 
-    For the convenience of java-tron node deployers, the TRON community provides a set of pre-configured Grafana dashboards. Refer to the [Import dashboard section](https://github.com/tronprotocol/tron-docker/blob/main/metric_monitor/README.md#import-dashboard) of the tron-docker metric_monitor README to import them into Grafana.
+    For the convenience of java-tron node deployers, the TRON community provides a set of pre-configured Grafana dashboards, each provided as a JSON file. Refer to the [Import dashboard section](https://github.com/tronprotocol/tron-docker/blob/main/metric_monitor/README.md#import-dashboard) of the tron-docker metric_monitor README to import them into Grafana.
 
     Click the Dashboards icon on the left, then select "+Import", then click "Upload JSON file" to import one of the JSON files mentioned above:
     
     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_import.png)
     
-    The dashboard will then display the monitoring metrics corresponding to the imported JSON file, allowing you to monitor the running status of the node in real time.
+    Grafana will then render the dashboard according to the imported JSON file, allowing you to monitor the running status of the node in real time.
 
 
 

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -56,7 +56,7 @@ After updating the configuration, start the node as described in [Starting a jav
           group: group-xxx
           instance: xxx-02
     ```
-    You can use this template and modify the targets configuration item, which specifies the IP address and Prometheus port of your java-tron node(s).
+    You can use this template and modify the targets configuration item, which specifies the IP address and Prometheus port of your java-tron node(s). Save the file to a local directory, for example `/Users/test/deploy/prometheus/prometheus.yaml`.
 
 3. Start a Prometheus container
 

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -1,5 +1,5 @@
 # java-tron Node Metrics Monitoring
-Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes expose a series of metrics endpoints in the Prometheus exposition format, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node, and obtain metric data from the node's metrics endpoint. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
+Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes expose metrics in the Prometheus exposition format on a `/metrics` endpoint, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node and scrape metric data from this endpoint. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
 
 ## Configure java-tron
 To use Prometheus for monitoring, you must first enable Prometheus metric monitoring and set the HTTP port in your node's configuration file. Locate the `node.metrics` block in `config.conf` and set `prometheus.enable` to `true`:
@@ -51,7 +51,7 @@ After updating the configuration, start the node as described in [Starting a jav
           group: group-xxx
           instance: xxx-01
       - targets:
-        - 172.0.0.2:9527
+        - 127.0.0.2:9527
         labels:
           group: group-xxx
           instance: xxx-02

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -2,24 +2,15 @@
 Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes provide a series of interfaces compatible with the Prometheus protocol, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node, and obtain the indicator data of the node through the node interface. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
 
 ## Configure java-tron 
-To use Prometheus for monitoring, you must first enable Prometheus metric monitoring and set the HTTP port in your node's configuration file:
+To use Prometheus for monitoring, you must first enable Prometheus metric monitoring and set the HTTP port in your node's configuration file. Locate the `node.metrics` block in `config.conf` and set `prometheus.enable` to `true`:
 
 ```
-node {
-  ... ...
-  p2p {
-    version = 11111 # 11111: mainnet; 20180622: testnet
+node.metrics = {
+  prometheus {
+    enable = true
+    port = 9527
   }
- ####### add for prometheus start.
- metrics{
-  prometheus{
-  enable=true 
-  port="9527"
-  }
- }
- ####### add for prometheus end.
 }
-
 ```
 ## Start java-tron node
 
@@ -71,7 +62,7 @@ After updating the configuration, start the node as described in [Starting a Ful
     
     ```
     $ docker run --name prometheus \
-        -d -p :9090:9090 \
+        -d -p 9090:9090 \
         -v  /Users/test/deploy/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml \
         prom/prometheus:latest
     ```

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -1,5 +1,5 @@
 # java-tron Node Metrics Monitoring
-Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes provide a series of interfaces compatible with the Prometheus protocol, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node, and obtain the indicator data of the node through the node interface. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
+Starting from the GreatVoyage-4.5.1 (Tertullian) version, java-tron nodes expose a series of metrics endpoints in the Prometheus exposition format, allowing node operators to monitor node health more conveniently. To monitor various node metrics, you must first deploy a Prometheus service to communicate with the java-tron node, and obtain the indicator data of the node through the node interface. Then you need to deploy a visualization tool, such as Grafana, to display the node data obtained by Prometheus in the form of a graphical interface. The following will introduce the deployment process of the java-tron node monitoring system in detail.
 
 ## Configure java-tron 
 To use Prometheus for monitoring, you must first enable Prometheus metric monitoring and set the HTTP port in your node's configuration file. Locate the `node.metrics` block in `config.conf` and set `prometheus.enable` to `true`:
@@ -79,7 +79,7 @@ After updating the configuration, start the node as described in [Starting a Ful
      
      In the example above, the status of the first endpoint is UP, meaning Prometheus can successfully fetch data from the node. The second endpoint shows DOWN, indicating an error (hover over the error label for details).
 
-     When the status of the monitored java-tron nodes is normal, you can monitor the indicator data through visualization tools such as Grafana or Promdash, etc. This article will use grafana to display the data:
+     When the status of the monitored java-tron nodes is normal, you can monitor the indicator data through visualization tools such as Grafana. This article will use Grafana to display the data:
 
 ## Deploy Grafana
 The deployment process of the Grafana visualization tool is as follows:

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -23,11 +23,7 @@ node {
 ```
 ## Start java-tron node
 
-Start java-tron node using the following command：
-
-```shell
-$  java -Xmx24g -XX:+UseConcMarkSweepGC -jar build/libs/FullNode.jar -c framework/src/main/resources/config.conf
-```
+After updating the configuration, start the node as described in [Starting a FullNode on the TRON main network](installing_javatron.md#starting-a-fullnode-on-the-tron-main-network).
 
 ## Deploy prometheus service
 


### PR DESCRIPTION
## Summary

- Align the `node.metrics` config example with the default in `framework/src/main/resources/config.conf` (drop the spurious extra `node { ... }` nesting and quoted port).
- Replace the duplicated start-command block with a link to the deployment guide via a new stable anchor (`#starting-a-java-tron-node`); private-network users are no longer steered to the mainnet section.
- Drop the obsolete Promdash reference; describe the endpoint as the Prometheus exposition format on `/metrics`.
- Replace the broken Grafana dashboard JSON link (`java-tron-template_rev1.json` on grafana.com) with a link to the [tron-docker `metric_monitor` README](https://github.com/tronprotocol/tron-docker/blob/main/metric_monitor/README.md), which hosts the current set of pre-configured dashboards.
- Add a link to the `All Metrics` section of the same README so readers can look up the meaning of each exposed metric.
- Mention where to save `prometheus.yaml` in Step 2 so the absolute path in the Step 3 `docker run -v` command is no longer abrupt.
- Fix loopback IP typo (`172.0.0.2` → `127.0.0.2`) in the example `targets`.
- Fix `docker run -p :9090:9090` typo to `-p 9090:9090`.
- Clarify the dashboard/JSON relationship in the Import Dashboard step.
- Numerous wording, capitalization (H2 title case), and list-indentation polish; remove the screenshot of a specific dashboard since each imported JSON renders differently.

## Test plan

- [x] Re-read the page end-to-end after edits; flow reads cleanly.
- [x] Verified the new `#starting-a-java-tron-node` anchor exists in `installing_javatron.md` and resolves under MkDocs.
- [x] Verified `https://github.com/tronprotocol/tron-docker/blob/main/metric_monitor/README.md#all-metrics` and `#import-dashboard` anchors both resolve on GitHub.
- [x] Cross-checked `node.metrics` example against `framework/src/main/resources/config.conf` and `Args.java` (default port 9527).
- [x] Confirmed introduction version "GreatVoyage-4.5.1 (Tertullian)" against `docs/releases/versions/index.md` (4.5.0 was never released externally; Prometheus metrics shipped with TIP-369 in 4.5.1).