### PR TITLE
Fix account model doc: creation fees, signing sample, and contract name

### DIFF
--- a/docs/mechanism-algorithm/account.md
+++ b/docs/mechanism-algorithm/account.md
@@ -22,7 +22,7 @@ There are two primary ways to create a new TRON account:
 
 **Method 2: Creation via System Contract**
 
-   - Developers can create an account by calling the `CreateAccount` system contract.
+   - Developers can create an account by calling the `AccountCreateContract` system contract.
 
 **Account Creation Cost:**
 

--- a/docs/mechanism-algorithm/account.md
+++ b/docs/mechanism-algorithm/account.md
@@ -75,7 +75,7 @@ The principle of Base58 encoding is to convert a large integer with a base of 25
 
 4. Concatenate the values of `r`, `s`, and `recoveryId` (or `r`, `s`, and `v`) to obtain the complete signature. The concatenation order shall be `r || s || recoveryId` (or `r || s || v`). At present, both the transaction signing in the official client `wallet-cli` and the block signing in `java-tron` (during block production by SRs) adopt the `recoveryId` scheme, i.e., `signature = r || s || recoveryId`.
 
-#### Java Code Sample
+### Java Code Sample
 
 ```java
 public static Transaction sign(Transaction transaction, ECKey myKey) {

--- a/docs/mechanism-algorithm/account.md
+++ b/docs/mechanism-algorithm/account.md
@@ -26,8 +26,8 @@ There are two primary ways to create a new TRON account:
 
 **Account Creation Cost:**
 
-   - A fixed fee of 1 TRX is required to create and activate a new account.
-   - Additionally, if the creator's account has sufficient Bandwidth (either from staking TRX or delegated from others), the creation will only consume Bandwidth. Otherwise, 0.1 TRX will be burned to pay for the Bandwidth fee.
+   - Activating a new account costs 1 TRX, which is burned. This amount is the `getCreateNewAccountFeeInSystemContract` network parameter (currently 1 TRX on mainnet) and can be changed by committee proposal.
+   - Additionally, if the creator's account has sufficient Bandwidth (either from staking TRX or delegated from others), the creation will only consume Bandwidth. Otherwise, the equivalent fee is burned to pay for the Bandwidth. This Bandwidth fee is the `getCreateAccountFee` network parameter (currently 0.1 TRX on mainnet) and can also be changed by committee proposal. Note that the daily free Bandwidth cannot be used to create an account; only Bandwidth obtained from staking TRX or delegated from others is eligible.
 
 ## Key Pair Generation Algorithm
 
@@ -84,7 +84,9 @@ public static Transaction sign(Transaction transaction, ECKey myKey) {
     ECDSASignature signature = myKey.sign(hash);
     ByteString bsSign = ByteString.copyFrom(signature.toByteArray());
     transactionBuilderSigned.addSignature(bsSign);
+    return transactionBuilderSigned.build();
 }
+```
 
 ## Signature Verification
 When a FullNode receives a transaction, it uses the transaction hash and signature to recover a public key via the ECDSA recovery mechanism (ecrecover). An address is then derived from this public key. If the derived address matches the originator's address specified in the transaction, the signature is considered valid.

--- a/docs/mechanism-algorithm/account.md
+++ b/docs/mechanism-algorithm/account.md
@@ -27,7 +27,7 @@ There are two primary ways to create a new TRON account:
 **Account Creation Cost:**
 
    - Activating a new account costs 1 TRX, which is burned. This amount is the `getCreateNewAccountFeeInSystemContract` network parameter (currently 1 TRX on mainnet) and can be changed by committee proposal.
-   - Additionally, if the creator's account has sufficient Bandwidth (either from staking TRX or delegated from others), the creation will only consume Bandwidth. Otherwise, the equivalent fee is burned to pay for the Bandwidth. This Bandwidth fee is the `getCreateAccountFee` network parameter (currently 0.1 TRX on mainnet) and can also be changed by committee proposal. Note that the daily free Bandwidth cannot be used to create an account; only Bandwidth obtained from staking TRX or delegated from others is eligible.
+   - Additionally, if the creator's account has sufficient Bandwidth (either from staking TRX or delegated from others), the creation will only consume Bandwidth. Otherwise, the `getCreateAccountFee` is burned to pay for the Bandwidth. This Bandwidth fee is a network parameter (currently 0.1 TRX on mainnet) and can also be changed by committee proposal. Note that the daily free Bandwidth cannot be used to create an account; only Bandwidth obtained from staking TRX or delegated from others is eligible.
 
 ## Key Pair Generation Algorithm
 


### PR DESCRIPTION
## Summary
- Describe the account activation fee and bandwidth fee as committee-adjustable network parameters (`getCreateNewAccountFeeInSystemContract`, `getCreateAccountFee`) with current mainnet values, instead of calling them fixed fees.
- Note that the daily free Bandwidth cannot be used to create an account; only staked or delegated Bandwidth is eligible.
- Correct the account creation contract name to `AccountCreateContract` (the actual `ContractType` enum value), instead of the non-existent `CreateAccount`.
- Complete the transaction signing Java sample (add the missing `return`) and close the unclosed code fence.
- Make the Java code sample a sibling of the Algorithm section for a symmetric heading structure.

## Test plan
- [x] Verified fee parameters and defaults against java-tron source (`DynamicPropertiesStore`, `ProposalUtil`, `BandwidthProcessor`) and mainnet `getchainparameters`.
- [x] Verified account creation skips free Bandwidth (`BandwidthProcessor.consumeForCreateNewAccount`).
- [x] Verified contract name against `protocol/.../core/Tron.proto` `ContractType` enum.
- [x] Verified the signing sample against `TransactionUtils.sign`.