### PR TITLE
Remove DEX page from nav and fix multi-sig cross-reference

### DIFF
--- a/docs/mechanism-algorithm/multi-signatures.md
+++ b/docs/mechanism-algorithm/multi-signatures.md
@@ -219,7 +219,7 @@ for (int id : contractId) {
 System.out.println(ByteArray.toHexString(operations));
 ```
 
->**Note**: The `contractId` above only illustrates the bit-setting logic. `ContractType` IDs are not contiguous (7, 21-29, 34-40, etc. are gaps), and a bit can only be set for a contract type already present in the on-chain `AVAILABLE_CONTRACT_TYPE` bitmap; otherwise the transaction is rejected during validation. `AVAILABLE_CONTRACT_TYPE` roughly corresponds to the `#` column in the table above, except it does not include ShieldedTransferContract(51).
+>**Note**: The `contractId` above only illustrates the bit-setting logic. `ContractType` IDs are not contiguous (7, 21-29, 34-40, etc. are gaps), and a bit can only be set for a contract type already present in the on-chain `AVAILABLE_CONTRACT_TYPE` bitmap; otherwise the transaction is rejected during validation. `AVAILABLE_CONTRACT_TYPE` roughly corresponds to the `#` column in the [ContractType Overview](./system-contracts.md#contracttype-overview) table, except it does not include ShieldedTransferContract(51).
 
 ### 3. Transaction Execution Process
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -258,7 +258,6 @@ nav:
         - Resource Model: mechanism-algorithm/resource.md
         - Smart Contract: contracts/contract.md
         - System Contract: mechanism-algorithm/system-contracts.md
-        - Decentralized Exchange: mechanism-algorithm/dex.md
         - Account Permission Management: mechanism-algorithm/multi-signatures.md
     - For java-tron Developers:
         - Developer Guide: developers/java-tron.md


### PR DESCRIPTION
## Summary
- Remove the outdated DEX page from site navigation. The native Bancor exchange is outdated compared to modern DEXes and is effectively non-functional since `ExchangeTransactionContract` is disabled; the source file is kept in the repo for reference.
- Fix a stale cross-reference in `multi-signatures.md`: the `ContractType` overview table moved to `system-contracts.md`, so the `AVAILABLE_CONTRACT_TYPE` note now links to the relocated table instead of referencing a non-existent local table.

## Test plan
- [x] `mkdocs.yml` nav no longer lists the DEX page; the entry is removed cleanly with valid YAML
- [x] `multi-signatures.md` link resolves to the `#contracttype-overview` anchor in `system-contracts.md`