### PR TITLE
docs: restore HTTP API XSS note and reorder machine-readable definitions

### DIFF
--- a/docs/api/http/index.md
+++ b/docs/api/http/index.md
@@ -16,6 +16,14 @@ The following categories are intentionally not covered:
 - **`permission_id`**: optional on builder endpoints; selects which `Permission` to use for multi-sig accounts.
 - **Amount unit**: TRC-10 amounts use the issuer-defined precision; every other amount is in sun (1 TRX = 1e6 sun).
 
+!!! warning "XSS security note"
+
+    Although the HTTP API reduces the risk of the browser parsing responses directly as HTML by setting `Content-Type` to `application/json`, this does not fully eliminate XSS. Some endpoints do not strictly validate their inputs, and responses may echo user-controlled content (especially when `visible=true`, where fields such as addresses and memos may be returned verbatim as UTF-8 strings). Before rendering any data returned by the API into a page, handle it safely according to the output context.
+
+    The correct approach is to choose the encoding that matches where the data is placed: in an HTML text context, use HTML entity encoding (e.g. `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`), or rely on your front-end framework's default output escaping (such as React JSX or Vue template escaping). Only use `encodeURIComponent()` and similar URL-encoding methods when the data is placed into a URL parameter. Note that `encodeURIComponent()` / `escape()` are URL encoding (or legacy encoding) and cannot replace output escaping in an HTML context.
+
+    For more guidance, see the [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html).
+
 ## Error responses
 
 In the vast majority of cases the HTTP status is **200** — business errors are conveyed in the response body, so the client must parse the body to determine success or failure. Known exceptions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,6 @@ nav:
         - Node Maintenance Tool: using_javatron/toolkit.md
     - API:
         - Overview: api/index.md
-        - Machine-readable definitions: api/interface-definitions.md
         - HTTP API:
             - Overview: api/http/index.md
             - Account:
@@ -252,6 +251,7 @@ nav:
                 - etherbase address: api/json-rpc/stub/eth_coinbase.md
                 - Node-managed accounts list: api/json-rpc/stub/eth_accounts.md
                 - Mining work info: api/json-rpc/stub/eth_getWork.md
+        - Machine-readable definitions: api/interface-definitions.md
     - Core Protocol:
         - DPoS: mechanism-algorithm/dpos.md
         - Super Representative: mechanism-algorithm/sr.md


### PR DESCRIPTION
## Summary

- Restore the XSS security note on the HTTP API index. This guidance existed in the original `http.md` but was dropped during the source-based API rewrite. It advises output encoding by output context (HTML entity encoding vs. URL encoding) and references the OWASP XSS Prevention Cheat Sheet. Placed next to the `visible` convention, since `visible=true` returns user-controlled text fields verbatim.
- Move the "Machine-readable definitions" entry to the end of the API nav section (after the JSON-RPC block), so the human-facing endpoint docs come first.

## Test plan

- [x] `api/http/index.md` renders the XSS note as a warning admonition
- [x] mkdocs nav shows "Machine-readable definitions" as the last item under API