### PR TITLE
update wallet-cli docs for 4.9.7

### DIFF
--- a/docs/clients/wallet-cli/accounts.md
+++ b/docs/clients/wallet-cli/accounts.md
@@ -198,7 +198,7 @@ The permission JSON has the following shape (keys, thresholds, and weighted sign
       "type": 2,
       "permission_name": "active",
       "threshold": 2,
-      "operations": "7fff1fc0033e0000000000000000000000000000000000000000000000000000",
+      "operations": "7fff1fc0033ef30f000000000000000000000000000000000000000000000000",
       "keys": [
         { "address": "TAbc...", "weight": 1 },
         { "address": "TDef...", "weight": 1 }
@@ -210,5 +210,7 @@ The permission JSON has the following shape (keys, thresholds, and weighted sign
 
 - `threshold` is the total signer weight required for the permission to authorize an action.
 - `operations` (active permissions only) is a 32-byte hex bitmap selecting which contract/operation
-  types the permission may perform.
+  types the permission may perform. The example above matches the 4.9.7 default active-permission
+  bitmap: it excludes disabled operation 51 (`ShieldedTransferContract`) while retaining active
+  operations such as 49 and 52.
 - `witness_permission` is only relevant for super-representative accounts.

--- a/docs/clients/wallet-cli/index.md
+++ b/docs/clients/wallet-cli/index.md
@@ -7,26 +7,36 @@ and talks to a TRON node primarily over gRPC (through the
 broadcast transactions. A few features (such as GasFree fee-delegated transfers) instead call the
 relevant service over HTTP.
 
-It offers two ways to drive it:
+It offers three ways to drive it:
 
-- **Interactive (REPL) mode** — a human-friendly shell with tab completion and interactive prompts.
-  Best for manual exploration and day-to-day wallet management.
-- **Standard CLI mode** — a non-interactive, scriptable interface with deterministic exit codes and
-  optional JSON output. Best for automation, scripts, CI/CD, and AI agents.
+- **Java Interactive (REPL) mode** — a human-friendly shell with tab completion and interactive
+  prompts. Best for manual exploration and day-to-day wallet management.
+- **Java Standard CLI mode** — a non-interactive, scriptable interface with deterministic exit codes
+  and optional JSON output. Best for automation and scripts that use the Java JAR.
+- **TypeScript / npm CLI** — a separate Node.js-based CLI introduced in 4.9.7 and published as
+  `@tron-walletcli/wallet-cli`. It uses grouped commands such as `tx send` and `account balance`,
+  and is designed for automation, CI/CD, and AI agents.
 
-Every command in this documentation is shown in both modes wherever it exists in both. Use the tabs
-to switch:
+The command reference pages below focus on the Java JAR's REPL and Standard CLI modes. For the
+Node.js command surface, see [TypeScript / npm CLI](typescript-cli.md). Use the tabs below to compare
+the same account query across the three entry points:
 
-=== "Standard CLI"
+=== "Java Standard CLI"
 
     ```bash
     java -jar build/libs/wallet-cli.jar --network nile get-account --address TXyz...
     ```
 
-=== "REPL"
+=== "Java REPL"
 
     ```
     GetAccount TXyz...
+    ```
+
+=== "TypeScript / npm CLI"
+
+    ```bash
+    wallet-cli account info --network tron:nile --account TXyz...
     ```
 
 ## Build

--- a/docs/clients/wallet-cli/staking.md
+++ b/docs/clients/wallet-cli/staking.md
@@ -13,15 +13,14 @@ Resource codes used throughout:
 |------|----------|
 | `0` | BANDWIDTH |
 | `1` | ENERGY |
-| `2` | TRON_POWER (voting power; REPL freeze/unfreeze only, network-gated) |
+| `2` | TRON_POWER (voting power; freeze/unfreeze only, network-gated) |
 
-Code `2` (TRON_POWER) is accepted only by the **REPL** freeze/unfreeze commands —
-`FreezeBalance`/`UnfreezeBalance` (Stake 1.0) and `FreezeBalanceV2`/`UnfreezeBalanceV2` (Stake 2.0).
-Even there it is network-gated: the node only allows a code-`2` freeze when the chain parameter
-`getAllowNewResourceModel` is enabled, which is **not** the case on mainnet — so in practice only
-`0`/`1` are usable. Every Standard CLI command that takes a `--resource` rejects anything other than
-`0` (BANDWIDTH) or `1` (ENERGY) up front with a usage error. Delegation commands (both modes)
-likewise accept only `0` or `1`.
+Code `2` (TRON_POWER) is network-gated for freeze/unfreeze commands:
+`FreezeBalance`/`UnfreezeBalance` (Stake 1.0), `FreezeBalanceV2`/`UnfreezeBalanceV2` (Stake 2.0),
+and their Standard CLI equivalents accept it only when the chain parameter
+`getAllowNewResourceModel` is enabled. If that chain parameter cannot be fetched, the 4.9.7 client
+fails open and lets the node validate the transaction at broadcast. Delegation commands (both modes)
+always accept only `0` or `1`; TRON_POWER is not delegatable.
 
 Amounts are in **SUN** (1 TRX = 1,000,000 SUN).
 
@@ -46,8 +45,9 @@ resource queries at the end of the page do not.
     ```
 
     - `--amount` (required, SUN), `--duration` (required, days).
-    - `--resource` (optional, `0`/`1`, default `0`). Standard CLI accepts only `0`/`1`; to freeze
-      for TRON_POWER (voting power, code `2`) use the REPL `FreezeBalance`.
+    - `--resource` (optional, `0`/`1`/`2`, default `0`). `2` is TRON_POWER and is allowed only when
+      `getAllowNewResourceModel` is enabled. If `--receiver` is set, the operation is delegated and
+      `2` is rejected.
     - `--receiver` (optional) — delegate the obtained resource to another address.
     - `--owner`, `--multi` (optional).
 
@@ -67,7 +67,9 @@ resource queries at the end of the page do not.
     java -jar build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
     ```
 
-    - `--resource` (optional, default `0`).
+    - `--resource` (optional, `0`/`1`/`2`, default `0`). `2` is TRON_POWER and is allowed only when
+      `getAllowNewResourceModel` is enabled. If `--receiver` is set, the operation targets a
+      delegated freeze and `2` is rejected.
     - `--receiver` (optional) — required if the resource was delegated.
     - `--owner`, `--multi` (optional).
 
@@ -90,7 +92,9 @@ No duration: staked TRX stays staked until you explicitly unstake it.
       --amount 1000000 --resource 1
     ```
 
-    - `--amount` (required, SUN), `--resource` (optional, default `0`).
+    - `--amount` (required, SUN), `--resource` (optional, `0`/`1`/`2`, default `0`).
+      `2` is TRON_POWER and is allowed only when `getAllowNewResourceModel` is enabled; if that
+      chain parameter cannot be fetched, the client lets the node validate at broadcast.
     - `--owner`, `--permission-id`, `--multi` (optional).
 
 === "REPL"
@@ -111,7 +115,9 @@ waiting period (see `withdraw-expire-unfreeze`).
       --amount 1000000 --resource 1
     ```
 
-    - `--amount` (required, SUN), `--resource` (optional, default `0`).
+    - `--amount` (required, SUN), `--resource` (optional, `0`/`1`/`2`, default `0`).
+      `2` is TRON_POWER and is allowed only when `getAllowNewResourceModel` is enabled; if that
+      chain parameter cannot be fetched, the client lets the node validate at broadcast.
     - `--owner`, `--permission-id`, `--multi` (optional).
 
 === "REPL"

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -1,9 +1,10 @@
 # TypeScript / npm CLI
 
-Starting with `wallet-cli` 4.9.7, the repository also ships an agent-first TypeScript CLI published
-as the npm package `@tron-walletcli/wallet-cli`. It is separate from the Java JAR described in the
-rest of this section: the Java CLI uses commands such as `send-coin`, while the TypeScript CLI uses
-grouped commands such as `tx send`.
+Starting with release 4.9.7 of the `wallet-cli` repository, the repository also ships an agent-first
+TypeScript CLI. This CLI is published as the npm package `@tron-walletcli/wallet-cli` and uses an
+independent npm version number; `wallet-cli --version` reports the npm package version. It is
+separate from the Java JAR described in the rest of this section: the Java CLI uses commands such
+as `send-coin`, while the TypeScript CLI uses grouped commands such as `tx send`.
 
 The TypeScript CLI currently supports TRON mainnet, Nile, and Shasta. EVM chains are not supported
 by this version.

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -1,0 +1,232 @@
+# TypeScript / npm CLI
+
+Starting with `wallet-cli` 4.9.7, the repository also ships an agent-first TypeScript CLI published
+as the npm package `@tron-walletcli/wallet-cli`. It is separate from the Java JAR described in the
+rest of this section: the Java CLI uses commands such as `send-coin`, while the TypeScript CLI uses
+grouped commands such as `tx send`.
+
+The TypeScript CLI currently supports TRON mainnet, Nile, and Shasta. EVM chains are not supported
+by this version.
+
+## Install
+
+Node.js 20 or later is required.
+
+```bash
+npm install -g @tron-walletcli/wallet-cli
+wallet-cli --version
+wallet-cli --help
+```
+
+## Quick start
+
+Create a local HD wallet, select it, and use Nile for test transactions:
+
+```bash
+wallet-cli create --label main
+wallet-cli list
+wallet-cli use main
+wallet-cli current
+wallet-cli config defaultNetwork tron:nile
+wallet-cli account balance
+```
+
+You can override the network for one command without changing the default:
+
+```bash
+wallet-cli account balance --network tron:nile
+```
+
+## Global options
+
+Common global options include:
+
+| Option | Description |
+|--------|-------------|
+| <code>--output text&#124;json</code>, <code>-o</code> | Select text or JSON output. |
+| `--network` | Network id, such as `tron:mainnet`, `tron:nile`, or `tron:shasta`. |
+| `--account` | Account id, label, or address; defaults to the active account set by `use`. |
+| `--timeout` | Per RPC/device-call timeout in milliseconds. |
+| `--verbose`, `-v` | Show extra diagnostics. |
+| `--wait` | After broadcast, poll until the transaction is confirmed or failed. |
+| `--wait-timeout` | Polling cap for `--wait`, in milliseconds. |
+| `--password-stdin` | Read the master password from stdin. |
+
+Command-scoped stdin flags include `--mnemonic-stdin`, `--private-key-stdin`, `--tx-stdin`, and
+`--message-stdin`. Only one `*-stdin` flag can consume stdin in a single invocation.
+
+## Wallets and accounts
+
+The TypeScript CLI stores its data under `~/.wallet-cli` by default. Set `WALLET_CLI_HOME` to isolate
+test or automation data.
+
+```bash
+WALLET_CLI_HOME=/tmp/wallet-cli-demo wallet-cli list --output json
+```
+
+Useful wallet commands:
+
+```bash
+wallet-cli create --label main
+wallet-cli import mnemonic --label imported
+wallet-cli import private-key --label hot
+wallet-cli import watch --address T... --label treasury
+wallet-cli import ledger --app tron --index 0 --label cold
+wallet-cli list
+wallet-cli use main
+wallet-cli current
+wallet-cli rename main --label primary
+wallet-cli backup primary --out ~/primary-backup.json
+```
+
+HD sub-account derivation is explicit in 4.9.7: pass the HD seed id shown by `wallet-cli list`.
+
+```bash
+wallet-cli derive --seed-id wlt_ab12cd34 --label operations
+```
+
+Deleting a root HD wallet cascades to accounts derived from that root and cleans orphan labels. In a
+non-interactive shell, pass `--yes`; otherwise the command asks for confirmation.
+
+```bash
+wallet-cli delete old --yes
+```
+
+## Transactions
+
+Amounts passed with `--amount` are human amounts. Use `--raw-amount` for SUN or token base units.
+
+```bash
+wallet-cli tx send --to T... --amount 1 --dry-run
+wallet-cli tx send --to T... --amount 1 --wait
+wallet-cli tx send --to T... --token USDT --amount 5
+wallet-cli tx send --to T... --contract TR7... --amount 5
+wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000
+```
+
+State-changing commands support three execution modes:
+
+| Mode | Behavior |
+|------|----------|
+| default | Build, sign, and broadcast. |
+| `--dry-run` | Build and estimate without signing or broadcasting. |
+| `--sign-only` | Sign and output the transaction without broadcasting. |
+
+Broadcast a signed transaction later with:
+
+```bash
+wallet-cli tx broadcast --tx-stdin < signed.json
+```
+
+`tx status` returns a four-state model: `confirmed`, `failed`, `pending`, or `not_found`.
+
+```bash
+wallet-cli tx status --txid <TXID>
+wallet-cli tx info --txid <TXID> --output json
+```
+
+## Queries and signing
+
+Wallet-bound account queries use the active account by default, or the account selected with
+`--account`.
+
+```bash
+wallet-cli account info --output json
+wallet-cli account history --limit 10
+wallet-cli account portfolio
+wallet-cli networks
+wallet-cli block
+wallet-cli block 12345
+wallet-cli message sign --message 'hello'
+```
+
+## Tokens and contracts
+
+The token address book includes common mainnet tokens such as USDT and USDC, and can be extended with
+custom TRC-20 contracts.
+
+```bash
+wallet-cli token add --contract TR7...
+wallet-cli token list
+wallet-cli token balance --contract TR7...
+wallet-cli token info --contract TR7...
+wallet-cli token remove --contract TR7...
+```
+
+Contract calls use JSON-encoded parameter descriptors:
+
+```bash
+wallet-cli contract info --contract TR7...
+
+wallet-cli contract call \
+  --contract T... \
+  --method 'balanceOf(address)' \
+  --params '[{"type":"address","value":"T..."}]'
+
+wallet-cli contract send \
+  --contract T... \
+  --method 'transfer(address,uint256)' \
+  --params '[{"type":"address","value":"T..."},{"type":"uint256","value":"1000000"}]' \
+  --dry-run
+
+wallet-cli contract deploy \
+  --abi '[...]' \
+  --bytecode 60... \
+  --fee-limit 1000000000 \
+  --params '[100,"T..."]' \
+  --dry-run
+```
+
+In JSON output, a successful TypeScript CLI contract deployment includes the deployed
+`contractAddress` in the deploy receipt data.
+
+Contract deployment requires a software account. The Ledger TRON app cannot sign
+`CreateSmartContract`, so Ledger-backed accounts cannot use `wallet-cli contract deploy`.
+
+## Stake 2.0
+
+Stake amounts are specified in SUN. The TypeScript CLI exposes Stake 2.0 commands:
+
+```bash
+wallet-cli stake freeze --amount-sun 1000000 --resource energy --dry-run
+wallet-cli stake delegate --amount-sun 1000000 --receiver T... --resource energy --dry-run
+wallet-cli stake undelegate --amount-sun 1000000 --receiver T... --resource energy --dry-run
+wallet-cli stake unfreeze --amount-sun 1000000 --resource energy --dry-run
+wallet-cli stake cancel-unfreeze --dry-run
+wallet-cli stake withdraw --dry-run
+```
+
+`stake cancel-unfreeze` requires a software account; the Ledger TRON app cannot sign
+`CancelAllUnfreezeV2Contract`.
+
+## Automation
+
+JSON mode emits one `wallet-cli.result.v1` envelope to stdout and uses deterministic exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. |
+| `1` | Execution, authentication, device, or chain error. |
+| `2` | Invalid command usage or arguments. |
+
+Agents and scripts can discover the complete command catalog and JSON Schemas without parsing
+human-readable help:
+
+```bash
+wallet-cli --json-schema
+wallet-cli tx send --json-schema
+```
+
+For secret input, pipe secrets through stdin rather than argv or exported environment variables:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" | wallet-cli message sign --message 'hello' --password-stdin --output json
+printf '%s\n' "$MNEMONIC" | wallet-cli import mnemonic --label main --mnemonic-stdin
+printf '%s\n' "$PRIVATE_KEY" | wallet-cli import private-key --label hot --private-key-stdin
+```
+
+These examples assume the shell variables are populated securely and are not exported. Only one
+`*-stdin` flag can consume stdin in each invocation. Commands such as `import mnemonic` and
+`import private-key` need both the master password and the mnemonic/private key; if you pipe one
+secret, the other must be entered interactively in a TTY. They cannot be completed as a fully
+non-interactive single-stdin invocation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,6 +285,7 @@ nav:
             - Governance: clients/wallet-cli/governance.md
             - GasFree: clients/wallet-cli/gasfree.md
             - Queries: clients/wallet-cli/query.md
+            - TypeScript / npm CLI: clients/wallet-cli/typescript-cli.md
     - Releases:
         - Deployment Manual for the New Version: releases/upgrade-instruction.md
         - Integrity Check: releases/signature_verification.md
@@ -393,4 +394,3 @@ plugins:
         - introduction/overview.md
         - mechanism-algorithm/shielded-TRC20-contract.md
         - mechanism-algorithm/trc10.md
-


### PR DESCRIPTION
## Summary

- Add a TypeScript/npm CLI reference page covering installation, wallet/account flows, transactions, queries, tokens, contracts, staking, JSON output, and stdin secret handling.
- Update the wallet-cli landing page and navigation to present Java REPL, Java standard CLI, and the new TypeScript/npm CLI entry point.
- Refresh 4.9.7 Java CLI details for account permission operation bitmaps and network-gated TRON_POWER staking resource handling.

## Test plan

- [x] Reviewed rendered pages locally; navigation shows the new TypeScript / npm CLI entry.
- [x] Verified tabbed examples display Java Standard CLI, Java REPL, and TypeScript / npm CLI variants.
- [x] Checked accounts and staking edits against the 4.9.7 client behavior.