### PR TITLE
improve CLI contracts and AI-readable documentation index

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Build the document
       run: mkdocs build
 
+    - name: Generate machine-readable documentation manifest
+      run: python3 scripts/generate_docs_manifest.py
+
     - name: Build and Deploy
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/docs/clients/wallet-cli/index.md
+++ b/docs/clients/wallet-cli/index.md
@@ -85,7 +85,9 @@ java -jar build/libs/wallet-cli.jar help --command send-coin
 
 ## Global options (Standard CLI)
 
-Global options come **before** the command name. They are parsed by `GlobalOptions`.
+Execution-modifier global options are parsed by `GlobalOptions` and may appear either **before or
+after** the command name. Top-level mode selectors have stricter placement rules, as described
+below.
 
 | Option | Values | Description |
 |--------|--------|-------------|
@@ -102,8 +104,14 @@ Global options come **before** the command name. They are parsed by `GlobalOptio
 
 Notes:
 
-- `--output` and `--network` accept their value either as the next token (`--network nile`) or
-  inline (`--network=nile`).
+- The execution modifiers `--network`, `--grpc-endpoint`, `--output`, `--wallet`, `--quiet`,
+  `--verbose`, and `--password-stdin` are recognized before or after the command name.
+- The top-level mode selectors `--version` and `--interactive` must appear before the command name.
+  After a command, they are treated as command-local arguments instead.
+- `--help` and `-h` before the command request global help; after the command they request help for
+  that command.
+- Valued global options (`--output`, `--network`, `--wallet`, and `--grpc-endpoint`) accept their
+  value either as the next token (`--network nile`) or inline (`--network=nile`).
 - Options that take a value cannot be repeated, and unknown global options are rejected.
 
 ## Authentication (Standard CLI)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,7 +14,7 @@
 - [Lite FullNode](https://tronprotocol.github.io/documentation-en/using_javatron/litefullnode/): Run and maintain a pruned, low-footprint node.
 - [Private Network](https://tronprotocol.github.io/documentation-en/using_javatron/private_network/): Stand up a private TRON chain.
 - [Node Monitoring](https://tronprotocol.github.io/documentation-en/using_javatron/metrics/): Prometheus / Grafana metrics and health endpoints.
-- [Node Maintenance Tool (Toolkit)](https://tronprotocol.github.io/documentation-en/using_javatron/toolkit/): Database partitioning, lite-node pruning, copy, LevelDB→RocksDB conversion, and startup optimization.
+- [Node Maintenance Tool (Toolkit)](https://tronprotocol.github.io/documentation-en/using_javatron/toolkit/): Database partitioning, lite-node pruning, copy, LevelDB→RocksDB conversion, startup optimization, and keystore management; documents the keystore commands' JSON output and exit behavior.
 - [Upgrade to a New Version](https://tronprotocol.github.io/documentation-en/releases/upgrade-instruction/): Upgrade procedure for new releases.
 
 ## APIs

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,6 +2,13 @@
 
 > java-tron is the official Java implementation of the TRON network client, maintained by the TRON protocol team. It implements the TRON mainnet protocol — DPoS consensus, Super Representatives, the account and resource models, smart contracts, system contracts, and multi-signature permissions — and is the software for running full nodes, participating in Super Representative elections, deploying contracts, and building DApps. This site is the authoritative documentation; the Chinese translation lives at documentation-zh.
 
+Use the documentation manifest to discover every page published in the site navigation. Each manifest entry provides both the canonical HTML URL and a direct `markdown_url` for the authoritative source text.
+
+## Machine-readable Resources
+
+- [Documentation manifest](https://tronprotocol.github.io/documentation-en/docs-manifest.json): Complete inventory of the Markdown pages published in the MkDocs navigation, including title, section, canonical HTML URL, direct Markdown URL, source path, and last-modified time.
+- [Markdown source tree](https://github.com/tronprotocol/documentation-en/tree/master/docs): Authoritative open-source Markdown content for the documentation site.
+
 ## Getting Started
 
 - [Getting Started Guide](https://tronprotocol.github.io/documentation-en/getting_started/getting_started_with_javatron/): First steps with java-tron and the TRON protocol.
@@ -13,6 +20,9 @@
 - [Backup and Restore](https://tronprotocol.github.io/documentation-en/using_javatron/backup_restore/): Snapshot and restore node databases.
 - [Lite FullNode](https://tronprotocol.github.io/documentation-en/using_javatron/litefullnode/): Run and maintain a pruned, low-footprint node.
 - [Private Network](https://tronprotocol.github.io/documentation-en/using_javatron/private_network/): Stand up a private TRON chain.
+- [Event Subscription](https://tronprotocol.github.io/documentation-en/architecture/event/): Subscribe to contract events and transaction logs through the supported event plugins and services.
+- [Database Configuration](https://tronprotocol.github.io/documentation-en/architecture/database/): Select LevelDB or RocksDB, configure storage, and migrate database formats.
+- [Network Connection](https://tronprotocol.github.io/documentation-en/using_javatron/connecting_to_tron/): Configure seed nodes, active/passive peers, connection limits, and network discovery.
 - [Node Monitoring](https://tronprotocol.github.io/documentation-en/using_javatron/metrics/): Prometheus / Grafana metrics and health endpoints.
 - [Node Maintenance Tool (Toolkit)](https://tronprotocol.github.io/documentation-en/using_javatron/toolkit/): Database partitioning, lite-node pruning, copy, LevelDB→RocksDB conversion, startup optimization, and keystore management; documents the keystore commands' JSON output and exit behavior.
 - [Upgrade to a New Version](https://tronprotocol.github.io/documentation-en/releases/upgrade-instruction/): Upgrade procedure for new releases.
@@ -25,6 +35,7 @@
 - [gRPC API reference](https://tronprotocol.github.io/documentation-en/api/rpc/): `protocol.Wallet` / `protocol.WalletSolidity` methods; contracts are defined by the `.proto` files in the java-tron repository.
 - [OpenAPI spec (HTTP)](https://tronprotocol.github.io/documentation-en/api/openapi.yaml): Machine-readable OpenAPI contract for the `/wallet/*` and `/walletsolidity/*` HTTP endpoints.
 - [OpenRPC spec (JSON-RPC)](https://tronprotocol.github.io/documentation-en/api/openrpc.json): Machine-readable OpenRPC contract for the `eth_*` / `net_*` / `web3_*` and `buildTransaction` methods.
+- [Machine-readable API definitions](https://tronprotocol.github.io/documentation-en/api/interface-definitions/): Scope, provenance, versioning, and generation details for the OpenAPI and OpenRPC contracts.
 
 ## Core Protocol
 
@@ -40,7 +51,17 @@
 
 - [Developer Guide](https://tronprotocol.github.io/documentation-en/developers/java-tron/): Building, contributing to, and extending java-tron.
 - [Core Modules](https://tronprotocol.github.io/documentation-en/developers/code-structure/): Source layout and module responsibilities.
+- [ChainBase Deep Dive](https://tronprotocol.github.io/documentation-en/developers/chainbase/): State storage architecture, database abstractions, and transaction processing.
+- [P2P Network Deep Dive](https://tronprotocol.github.io/documentation-en/developers/network/): Peer discovery, connection management, synchronization, and message handling.
+- [TIPs Workflow](https://tronprotocol.github.io/documentation-en/developers/tip-workflow/): Propose and review protocol changes through TRON Improvement Proposals.
+- [Issue Workflow](https://tronprotocol.github.io/documentation-en/developers/issue-workflow/): Report, triage, and resolve java-tron issues.
+- [Governance Workflow](https://tronprotocol.github.io/documentation-en/developers/governance/): Contributor roles, pull-request review, and repository governance.
 - [wallet-cli](https://tronprotocol.github.io/documentation-en/clients/wallet-cli/): Official command-line wallet and key management.
+
+## Releases
+
+- [Release History](https://tronprotocol.github.io/documentation-en/releases/versions/): Version-by-version changes and source references.
+- [Release Integrity Verification](https://tronprotocol.github.io/documentation-en/releases/signature_verification/): Verify release signatures and checksums before deployment.
 
 ## Optional
 

--- a/docs/using_javatron/installing_javatron.md
+++ b/docs/using_javatron/installing_javatron.md
@@ -385,7 +385,16 @@ To avoid specifying the private key in plaintext within the configuration file, 
         localwitnesskeystore = ["B/localwitnesskeystore.json"]
         ```
 
-    * You can use the `registerwallet` command from the `wallet-cli` project to generate the `keystore` file and password, or use the command `java -jar build/libs/FullNode.jar --keystore-factory` to generate them (starting from version 4.8.1, `KeystoreFactory.jar` is no longer provided).
+    * For an existing SR, the keystore must encrypt the private key corresponding to the address that is currently authorized on-chain to produce blocks. By default, this is the SR account address. If block-production authority has been assigned through the SR's witness permission to a different address, use the private key corresponding to that authorized address. Use Toolkit's [`keystore import`](toolkit.md#import-a-private-key) to create the encrypted keystore from the existing key:
+
+        ```bash
+        # Encrypt the currently authorized block-signing private key in a keystore
+        java -jar build/libs/Toolkit.jar keystore import
+        ```
+
+        Do not use `keystore new` merely to migrate an existing SR: it generates a random key that cannot produce blocks for that SR unless its derived address is first authorized as the SR's witness permission. For a new SR identity, or as part of a planned witness-permission rotation, you may generate a new key with [`keystore new`](toolkit.md#generate-a-keystore) or the `registerwallet` command from `wallet-cli`, then complete the required on-chain registration or permission update before starting block production.
+
+        `java -jar build/libs/FullNode.jar --keystore-factory` remains available for compatibility but is deprecated and will be removed in a future release. Starting from version 4.8.1, a separate `KeystoreFactory.jar` is no longer provided.
 
 2. **Starting a Block Production Node**:
 

--- a/docs/using_javatron/toolkit.md
+++ b/docs/using_javatron/toolkit.md
@@ -8,6 +8,7 @@ The TRON Toolkit is a comprehensive utility that integrates various ecosystem to
 * [Data Conversion](#data-conversion-tool): Supports data format conversion from LevelDB to RocksDB.
 * [LevelDB Startup Optimization](#leveldb-startup-optimization-tool): Accelerates the startup speed for nodes using LevelDB.
 * [Merkle Root Computation](#merkle-root-computation-tool): Computes the Merkle root of a small database for verification purposes.
+* [Keystore Management](#keystore-management): Generates, imports, lists, and updates account keystore files.
 
 This document provides a detailed guide on how to acquire and use the TRON Toolkit.
 
@@ -35,6 +36,134 @@ You can obtain the `Toolkit.jar` file either by compiling the `java-tron` source
    ```
 
 Upon successful compilation, the `Toolkit.jar` artifact will be located in the `java-tron/build/libs/` directory.
+
+## Command-Line Output and Exit Behavior
+
+Toolkit uses command-specific output and exit codes. It does **not** currently provide a global JSON output option or a single error envelope shared by every command.
+
+* When Toolkit is invoked with a command, the process exits with the integer returned by that command. Invalid command-line syntax is handled by Picocli and exits with code `2`.
+* Invoking Toolkit without arguments prints the top-level usage and completes with exit code `0`.
+* The `keystore` commands described below return `0` after a successful operation and normally return `1` after an execution failure. `keystore list` also returns `0` when the directory is missing or contains no keystores.
+* `--json` is a per-command option supported only by `keystore new`, `keystore import`, `keystore list`, and `keystore update`. It controls successful output written to stdout. Errors and warnings remain plain text on stderr, including when `--json` is present.
+* The `db` commands do not support JSON output and retain command-specific exit-code behavior. Automation must not assume a Toolkit-wide `0`/`1`/`2` contract beyond the behavior explicitly documented for a command.
+
+For shell automation, check the exit code before parsing stdout. Do not attempt to parse stderr as JSON.
+
+## Keystore Management
+
+The `keystore` command group manages account keystore files in Web3 Secret Storage format. It replaces the deprecated interactive `FullNode.jar --keystore-factory` workflow.
+
+```bash
+java -jar build/libs/Toolkit.jar keystore --help
+```
+
+The default keystore directory is `Wallet` under the current working directory. Use `--keystore-dir <path>` to select another directory.
+
+### Generate a Keystore
+
+`keystore new` generates a random key pair and writes an encrypted keystore file:
+
+```bash
+# Interactive password entry
+java -jar build/libs/Toolkit.jar keystore new
+
+# Non-interactive password input and JSON result
+java -jar build/libs/Toolkit.jar keystore new \
+  --keystore-dir /data/keystores \
+  --password-file /secure/path/password.txt \
+  --json
+```
+
+Successful JSON output contains the generated address and filename:
+
+```json
+{"address":"T...","file":"UTC--...json"}
+```
+
+### Import a Private Key
+
+`keystore import` imports a 32-byte private key written as 64 hexadecimal characters. A leading `0x` or `0X` is accepted.
+
+```bash
+# Interactive private-key and password entry
+java -jar build/libs/Toolkit.jar keystore import
+
+# Non-interactive import
+java -jar build/libs/Toolkit.jar keystore import \
+  --keystore-dir /data/keystores \
+  --key-file /secure/path/private-key.txt \
+  --password-file /secure/path/password.txt \
+  --json
+```
+
+Successful JSON output has the same `address` and `file` fields as `keystore new`.
+
+By default, the command refuses to import a key when a keystore for the derived address already exists in the target directory. Pass `--force` only when creating an additional keystore for the same address is intentional.
+
+### List Keystores
+
+`keystore list` lists structurally valid `.json` keystore files in a directory:
+
+```bash
+java -jar build/libs/Toolkit.jar keystore list --keystore-dir /data/keystores
+java -jar build/libs/Toolkit.jar keystore list --keystore-dir /data/keystores --json
+```
+
+Successful JSON output wraps the results in a `keystores` array:
+
+```json
+{
+  "keystores": [
+    {"address":"T...","file":"UTC--...json"}
+  ]
+}
+```
+
+If the directory does not exist or contains no valid keystores, JSON mode returns `{"keystores":[]}` with exit code `0`. Unreadable or malformed `.json` files are skipped and may produce warnings on stderr.
+
+`keystore list` does not decrypt each file. The displayed address is the address declared inside the keystore JSON and is not cryptographically verified by this command. Only trust keystores from sources you control.
+
+### Update a Keystore Password
+
+`keystore update` locates a keystore by address, decrypts it with the current password, and rewrites it with a new password through a temporary file. Toolkit attempts an atomic replacement and falls back to a regular replacement when the filesystem does not support atomic moves:
+
+```bash
+# Interactive password entry
+java -jar build/libs/Toolkit.jar keystore update T... \
+  --keystore-dir /data/keystores
+
+# Non-interactive password update
+java -jar build/libs/Toolkit.jar keystore update T... \
+  --keystore-dir /data/keystores \
+  --password-file /secure/path/passwords.txt \
+  --json
+```
+
+For `update`, the password file must contain exactly two lines: the current password on the first line and the new password on the second line.
+
+Successful JSON output contains the verified address, filename, and update status:
+
+```json
+{"address":"T...","file":"UTC--...json","status":"updated"}
+```
+
+The command fails if no matching keystore exists or if more than one valid keystore declares the requested address. It does not choose arbitrarily between duplicates.
+
+### Keystore Options and Security
+
+| Option | Commands | Behavior |
+|---|---|---|
+| `--keystore-dir <path>` | all | Keystore directory; defaults to `Wallet`. |
+| `--json` | all | Writes the successful result as JSON to stdout; errors remain text on stderr. |
+| `--password-file <file>` | `new`, `import`, `update` | Avoids an interactive password prompt. `new` and `import` require one line; `update` requires exactly two lines. |
+| `--key-file <file>` | `import` | Reads the private key from a file instead of a terminal prompt. |
+| `--force` | `import` | Allows another keystore to be created for an address already present in the directory. |
+| `--sm2` | `new`, `import`, `update` | Uses SM2 instead of the default ECDSA engine. For `update`, it must match the algorithm used by the existing keystore. |
+
+Password and private-key input files must be regular files no larger than 1,024 bytes; symbolic links are rejected. Passwords selected by `keystore new` and `keystore import`, and the new password supplied to `keystore update`, must contain at least six characters. `keystore update` does not apply this minimum to the existing password so that legacy keystores remain accessible. On POSIX systems, Toolkit creates or rewrites keystore files with owner-only `0600` permissions.
+
+!!! warning "Protect temporary secret files"
+    `--password-file` and `--key-file` make non-interactive execution possible, but the files contain secrets in plaintext. Store them outside the repository, restrict them to the current user with `chmod 600`, never commit them, and remove them when they are no longer required.
 
 
 ## Database Partitioning Tool

--- a/scripts/generate_docs_manifest.py
+++ b/scripts/generate_docs_manifest.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Generate the machine-readable documentation manifest published by MkDocs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from urllib.parse import quote
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = REPOSITORY_ROOT / "docs"
+MKDOCS_CONFIG = REPOSITORY_ROOT / "mkdocs.yml"
+DEFAULT_OUTPUT_PATH = REPOSITORY_ROOT / "site" / "docs-manifest.json"
+SITE_URL = "https://tronprotocol.github.io/documentation-en/"
+SOURCE_ROOT = "https://raw.githubusercontent.com/tronprotocol/documentation-en/master/docs/"
+
+
+def document_title(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"^#\s+(.+?)\s*$", text, flags=re.MULTILINE)
+    if match:
+        return re.sub(r"\s+#+$", "", match.group(1)).strip()
+    return path.stem.replace("_", " ").replace("-", " ").title()
+
+
+def nav_documents(items: list[object], top_section: str | None = None):
+    """Yield Markdown paths and their top-level nav section in nav order."""
+    for item in items:
+        if isinstance(item, str):
+            if item.endswith(".md"):
+                yield Path(item), top_section or "Other"
+            continue
+        if not isinstance(item, dict):
+            continue
+        for label, value in item.items():
+            section = top_section or str(label)
+            if isinstance(value, str):
+                if value.endswith(".md"):
+                    yield Path(value), section
+            elif isinstance(value, list):
+                yield from nav_documents(value, section)
+
+
+def configured_documents() -> list[tuple[Path, str]]:
+    config = yaml.safe_load(MKDOCS_CONFIG.read_text(encoding="utf-8"))
+    nav = config.get("nav")
+    if not isinstance(nav, list):
+        raise ValueError("mkdocs.yml must contain a list-valued nav section")
+
+    documents = []
+    seen = set()
+    for relative_path, section in nav_documents(nav):
+        if relative_path in seen:
+            continue
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError(f"Navigation page must stay inside docs/: {relative_path}")
+        source_path = DOCS_ROOT / relative_path
+        if not source_path.is_file():
+            raise FileNotFoundError(f"Navigation page does not exist: {relative_path}")
+        seen.add(relative_path)
+        documents.append((relative_path, section))
+    return documents
+
+
+def html_url(relative_path: Path) -> str:
+    if relative_path == Path("index.md"):
+        suffix = ""
+    elif relative_path.name == "index.md":
+        suffix = relative_path.parent.as_posix().rstrip("/") + "/"
+    else:
+        suffix = relative_path.with_suffix("").as_posix().rstrip("/") + "/"
+    return SITE_URL + quote(suffix, safe="/")
+
+
+def markdown_url(relative_path: Path) -> str:
+    return SOURCE_ROOT + quote(relative_path.as_posix(), safe="/")
+
+
+def last_modified(source_path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%cI", "--", source_path],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    value = result.stdout.strip()
+    return value or None
+
+
+def build_manifest() -> dict[str, object]:
+    documents = []
+    for relative_path, section in configured_documents():
+        path = DOCS_ROOT / relative_path
+        source_path = (Path("docs") / relative_path).as_posix()
+        documents.append(
+            {
+                "title": document_title(path),
+                "section": section,
+                "html_url": html_url(relative_path),
+                "markdown_url": markdown_url(relative_path),
+                "source_path": source_path,
+                "last_modified": last_modified(source_path),
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "project": "java-tron documentation",
+        "language": "en",
+        "site_url": SITE_URL,
+        "source_repository": "https://github.com/tronprotocol/documentation-en",
+        "source_branch": "master",
+        "documents": documents,
+        "machine_readable_assets": [
+            {
+                "name": "LLM entry index",
+                "url": SITE_URL + "llms.txt",
+                "source_path": "docs/llms.txt",
+            },
+            {
+                "name": "HTTP OpenAPI specification",
+                "url": SITE_URL + "api/openapi.yaml",
+                "source_path": "docs/api/openapi.yaml",
+            },
+            {
+                "name": "JSON-RPC OpenRPC specification",
+                "url": SITE_URL + "api/openrpc.json",
+                "source_path": "docs/api/openrpc.json",
+            },
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="output path (default: site/docs-manifest.json)",
+    )
+    args = parser.parse_args()
+    output_path = args.output if args.output.is_absolute() else REPOSITORY_ROOT / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(build_manifest(), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Background

This change fills two documentation gaps that affect automation tools and AI agents: explicit command-line contracts for Toolkit and wallet-cli, and a machine-discoverable index of the published documentation. The goal is to make CLI output, argument syntax, and the documentation structure reliably consumable without duplicating the entire site or introducing a large full-text snapshot that can become stale.

## What changed

### 1. Document Toolkit CLI and keystore behavior

- Document Toolkit output modes, JSON success and error envelopes, and exit-code behavior.
- Add guidance for keystore management, private-key import, and the related security considerations.
- Add SR keystore guidance to the java-tron installation and operation documentation, with links to the relevant Toolkit section.
- Give scripts and automated clients a defined way to process Toolkit results instead of inferring success or failure from human-readable terminal output.

### 2. Align the wallet-cli global-option syntax with the implementation

- Clarify the distinction between startup options and per-command execution modifiers, including where each form may appear.
- Document the inline-value forms `--output=...`, `--network=...`, `--wallet=...`, and `--grpc-endpoint=...`.


### 3. Improve AI and machine discoverability

- Expand the curated `llms.txt` so agents have stable entry points to high-value documentation.
- Add `scripts/generate_docs_manifest.py`, which reads the `nav` section of `mkdocs.yml` and generates `site/docs-manifest.json` from the Markdown pages that are actually published.
- Include each page's title, top-level navigation section, HTML URL, raw Markdown URL, source path, and Git last-modified timestamp in the manifest.
- Include machine-readable resources such as `llms.txt`, the HTTP OpenAPI specification, and the JSON-RPC OpenRPC specification.
- Run the generator after `mkdocs build` in the gh-pages workflow so the manifest is produced for the same site revision being deployed.
- Limit discovery to Markdown pages listed in the MkDocs navigation, excluding drafts, unpublished pages, and repository-internal files.

## Why this does not add `llms-full.txt`

The repository content is already public, and the manifest provides a complete, enumerable list of published pages together with direct raw Markdown URLs. Generating `llms-full.txt` would duplicate the full documentation body, increase artifact size and context usage, introduce another synchronization risk, and encourage clients to load large amounts of irrelevant content at once.

This change instead uses a layered discovery model:

- `llms.txt` provides a curated set of high-value entry points;
- `docs-manifest.json` provides complete discovery of all published pages;
- each `markdown_url` allows clients to retrieve only the source content they need.

This preserves complete discoverability while supporting efficient retrieval and progressive loading by agents.

## Impact

- No java-tron, Toolkit, or wallet-cli runtime behavior is changed.
- Existing documentation URLs and navigation structure remain unchanged.
- The gh-pages artifact gains `/docs-manifest.json`, and `/llms.txt` receives additional curated entries.
- The manifest is generated during publication rather than maintained as a second static copy under `docs/`, avoiding divergence between source and deployed artifacts.

## Validation

- Built the MkDocs site in both the English and Chinese documentation repositories.
- Ran the manifest generator directly in both repositories and confirmed that it parses the current `mkdocs.yml` configuration.
- Confirmed that the manifest contains only Markdown pages present in the navigation, with no duplicate HTML URLs or missing Git last-modified timestamps.
- Verified that project, language, source-repository, and machine-resource metadata match the corresponding documentation repository.
