### PR TITLE
align database documentation with java-tron v4.8.2

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -52,6 +52,8 @@ dbSettings = {
 }
 ```
 
+Starting with java-tron v4.8.2, the periodic RocksDB backup feature configured through `storage.backup` has been removed. Existing `storage.backup` settings are ignored, and java-tron no longer creates periodic database copies through this mechanism.
+
 ## Migrating from LevelDB to RocksDB on x86_64 Platforms
 
 To migrate from LevelDB to RocksDB, use the TRON Toolkit `Toolkit.jar`.

--- a/docs/using_javatron/litefullnode.md
+++ b/docs/using_javatron/litefullnode.md
@@ -24,6 +24,8 @@ The deployment steps, configuration files, and startup commands for a Lite FullN
 - Download the Lite FullNode data snapshot from the [Public Backup Data](backup_restore.md/#lite-fullnode-data-snapshots) and use it directly.
 - Use the [Lite FullNode Pruning Tool](toolkit.md/#lite-fullnode-data-pruning) to convert a FullNode's database into a Lite FullNode's database.
 
+When creating your own snapshot, the pruning tool keeps the `balance-trace` and `account-trace` databases by default. If historical balance queries are not required, you can use `--exclude-historical-balance` with `split -t snapshot` to reduce the snapshot size. This exclusion cannot be reversed by merging a history dataset; do not enable it if the resulting Lite FullNode must support historical balance queries. See [Lite FullNode Data Pruning](toolkit.md/#lite-fullnode-data-pruning) for the command and complete warning.
+
 ## Lite FullNode Maintenance
 
 Although a Lite FullNode starts with a minimal data footprint, it continuously syncs and saves new block data during operation. Consequently, its data expansion rate matches that of a standard FullNode, and its disk usage will grow over time.

--- a/docs/using_javatron/toolkit.md
+++ b/docs/using_javatron/toolkit.md
@@ -281,10 +281,12 @@ Use the `db lite` command to perform data pruning operations:
 
 ```bash
 # full command
-  java -jar build/libs/Toolkit.jar db lite [-h] -ds=<datasetPath> -fn=<fnDataPath> [-o=<operate>] [-t=<type>]
+  java -jar build/libs/Toolkit.jar db lite [-h] -ds=<datasetPath> -fn=<fnDataPath> [-o=<operate>] [-t=<type>] [--exclude-historical-balance]
 # examples
   #split and get a snapshot dataset
   java -jar build/libs/Toolkit.jar db lite -o split -t snapshot --fn-data-path output-directory/database --dataset-path /tmp
+  #split and get a smaller snapshot without historical balance data
+  java -jar build/libs/Toolkit.jar db lite -o split -t snapshot --fn-data-path output-directory/database --dataset-path /tmp --exclude-historical-balance
   #split and get a history dataset
   java -jar build/libs/Toolkit.jar db lite -o split -t history --fn-data-path output-directory/database --dataset-path /tmp
   #merge history dataset and snapshot dataset
@@ -301,6 +303,9 @@ Use the `db lite` command to perform data pruning operations:
 *   `-ds | --dataset-path <string>`：
     *   For `split`, this is the output directory for the generated snapshot or history dataset.
     *   For `merge`, this is the directory of the history dataset.
+*   `--exclude-historical-balance`: Used only with `-o split -t snapshot`. Default: `false`. When enabled, the tool excludes the `balance-trace` and `account-trace` databases from the snapshot to reduce its size. `split -t history` and `merge` ignore this option.
+
+    > **Warning:** If the source node has `storage.balance.history.lookup = true`, enabling this option permanently removes the data required for historical balance queries from the generated snapshot. A Lite FullNode started from that snapshot cannot safely serve `getblockbalance`, and `getaccountbalance` may return a balance of `0` when account trace data is unavailable. Merging a history dataset later does not restore the excluded databases. Do not enable this option if the resulting Lite FullNode must support historical balance queries.
 
 
 ### Usage Examples
@@ -323,6 +328,14 @@ java -jar build/libs/Toolkit.jar db lite -o split -t snapshot --fn-data-path out
 * `--dataset-path`: The output directory for the generated snapshot dataset.
 
 After the command completes, a directory named `snapshot` will be created in the `/tmp` directory. This directory contains the Lite FullNode data. To use it, copy the data from the snapshot directory to your node's database directory (e.g., rename the `snapshot` directory to database and move it to the Lite FullNode's `output-directory`), and then restart the node.
+
+If historical balance queries are not required, you can generate a smaller snapshot by excluding the balance trace databases:
+
+```shell
+java -jar build/libs/Toolkit.jar db lite -o split -t snapshot --fn-data-path output-directory/database --dataset-path /tmp --exclude-historical-balance
+```
+
+This exclusion is permanent for the generated snapshot. Do not use it when `storage.balance.history.lookup` must remain available on the resulting Lite FullNode.
 
 
 


### PR DESCRIPTION
Align the database documentation with the database-related changes in java-tron v4.8.2.

## Changes

- **Lite snapshot balance exclusion**: documented the `--exclude-historical-balance` option added to `db lite split -t snapshot`. The option excludes the `balance-trace` and `account-trace` databases to reduce snapshot size; the default behavior remains unchanged.
- **Historical balance compatibility**: documented that snapshots created with this option cannot safely serve historical balance queries when the source node has `storage.balance.history.lookup = true`, and that merging a history dataset does not restore the excluded databases.
- **Lite FullNode guidance**: added the option to the snapshot creation workflow and linked to the complete command and compatibility warning.
- **Periodic RocksDB backups**: documented that the `storage.backup` feature was removed in java-tron v4.8.2, existing settings are ignored, and java-tron no longer creates periodic database copies through this mechanism.

## Test plan

- [x] Verified every claim against the corresponding java-tron v4.8.2 PRs
- [x] Confirmed `mkdocs build --strict` and `git diff --check` pass