### PR TITLE
align network documentation with java-tron v4.8.2

### DIFF
--- a/docs/api/http/tx-build-and-broadcast/broadcasthex.md
+++ b/docs/api/http/tx-build-and-broadcast/broadcasthex.md
@@ -9,7 +9,7 @@ Broadcast a signed transaction whose payload is the protobuf-hex encoding of `Tr
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `transaction` | string | Yes | Hex of the protobuf serialization of a complete `protocol.Transaction` |
+| `transaction` | string | Yes | Hex of the protobuf serialization of a complete `protocol.Transaction`. Each embedded signature must be `65`–`68` bytes; otherwise broadcast returns `SIGERROR` |
 
 Example:
 

--- a/docs/api/http/tx-build-and-broadcast/broadcasttransaction.md
+++ b/docs/api/http/tx-build-and-broadcast/broadcasttransaction.md
@@ -14,8 +14,10 @@ Pass the JSON form of `protocol.Transaction` directly (i.e., the response from `
 |---|---|---|---|
 | `raw_data` | object | Yes | Same as `createtransaction` response; the node re-serializes it into protobuf bytes for SHA256 signature verification |
 | `raw_data_hex` | string | No (node ignores) | Client-side display helper — the protobuf encoding of `raw_data`. **Not a proto field of `protocol.Transaction`**; `JsonFormat.merge` skips it during parse, so the node neither reads it nor cross-checks it against `raw_data`. Clients usually SHA256 it to derive `txID` when signing, but whether it matches or is even valid hex when broadcast does not affect processing |
-| `signature` | string[] | No | Optional at JSON/Protobuf parsing time. An ordinary transaction normally needs one valid signature to broadcast successfully; multi-sig transactions must satisfy the selected permission threshold. Missing signatures normally lead to a later `SIGERROR` |
+| `signature` | string[] | No | Optional at JSON/Protobuf parsing time. Each hex-encoded signature must decode to `65`–`68` bytes (normally `130`–`136` hex characters); a supplied signature outside this range is rejected immediately with `SIGERROR`. An ordinary transaction normally needs one valid signature to broadcast successfully, while multi-sig transactions must satisfy the selected permission threshold. A missing or cryptographically invalid signature normally results in `SIGERROR` when signature validation is reached |
 | `visible` | bool | No | Format of address / text fields |
+
+The same signature-length validation is applied to transactions submitted through the gRPC `BroadcastTransaction` method and other API endpoints that use the node's transaction broadcast path.
 
 Example:
 
@@ -70,7 +72,7 @@ Business-level errors are **still returned in the same `result/code/message` sha
 
 | code | Meaning |
 |---|---|
-| `SIGERROR` | Signature verification failed |
+| `SIGERROR` | Signature verification failed, or a supplied signature is shorter than `65` bytes or longer than `68` bytes |
 | `CONTRACT_VALIDATE_ERROR` | Pre-execution contract validation failed (insufficient balance, invalid params, etc.) |
 | `CONTRACT_EXE_ERROR` | Failed during execution |
 | `BANDWITH_ERROR` | Insufficient bandwidth |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3929,12 +3929,24 @@
               "allOf":
                 -
                   "$ref": "#/components/schemas/TransactionRequest"
+                -
+                  "type": "object"
+                  "properties":
+                    "signature":
+                      "type": "array"
+                      "items":
+                        "type": "string"
+                        "description": "Hex-encoded transaction signature. After hexadecimal decoding, including removal of an optional lowercase `0x` prefix and left-padding of an odd number of hexadecimal digits, each supplied signature must be 65\u201368 bytes; otherwise broadcast returns `SIGERROR`."
+                      "description": "Transaction signatures supplied for broadcast."
               "required":
                 - "raw_data"
       "x-overlay-derived": true
       "x-source-refs":
         - "framework/src/main/java/org/tron/core/services/http/BroadcastServlet.java"
         - "framework/src/main/java/org/tron/core/services/http/Util.java"
+        - "framework/src/main/java/org/tron/core/Wallet.java"
+        - "crypto/src/main/java/org/tron/common/crypto/SignUtils.java"
+        - "common/src/main/java/org/tron/core/Constant.java"
         - "protocol/src/main/protos/core/Tron.proto#Transaction"
   "/wallet/broadcasthex":
     "post":
@@ -4046,7 +4058,7 @@
               "properties":
                 "transaction":
                   "type": "string"
-                  "description": "Transaction object."
+                  "description": "Hex-encoded serialized `protocol.Transaction`. Each signature embedded in the decoded protobuf transaction must be 65\u201368 bytes; otherwise broadcast returns `SIGERROR`."
               "required":
                 - "transaction"
               "x-source-shape": "servlet-json-fields"
@@ -4055,6 +4067,9 @@
       "x-source-refs":
         - "framework/src/main/java/org/tron/core/services/http/BroadcastHexServlet.java"
         - "framework/src/main/java/org/tron/core/services/http/Util.java"
+        - "framework/src/main/java/org/tron/core/Wallet.java"
+        - "crypto/src/main/java/org/tron/common/crypto/SignUtils.java"
+        - "common/src/main/java/org/tron/core/Constant.java"
   "/wallet/createassetissue":
     "post":
       "tags":

--- a/docs/api/specs/http/broadcasthex.yaml
+++ b/docs/api/specs/http/broadcasthex.yaml
@@ -108,7 +108,7 @@
             "properties":
               "transaction":
                 "type": "string"
-                "description": "Transaction object."
+                "description": "Hex-encoded serialized `protocol.Transaction`. Each signature embedded in the decoded protobuf transaction must be 65\u201368 bytes; otherwise broadcast returns `SIGERROR`."
             "required":
               - "transaction"
             "x-source-shape": "servlet-json-fields"
@@ -117,3 +117,6 @@
     "x-source-refs":
       - "framework/src/main/java/org/tron/core/services/http/BroadcastHexServlet.java"
       - "framework/src/main/java/org/tron/core/services/http/Util.java"
+      - "framework/src/main/java/org/tron/core/Wallet.java"
+      - "crypto/src/main/java/org/tron/common/crypto/SignUtils.java"
+      - "common/src/main/java/org/tron/core/Constant.java"

--- a/docs/api/specs/http/broadcasttransaction.yaml
+++ b/docs/api/specs/http/broadcasttransaction.yaml
@@ -104,10 +104,22 @@
             "allOf":
               -
                 "$ref": "#/components/schemas/TransactionRequest"
+              -
+                "type": "object"
+                "properties":
+                  "signature":
+                    "type": "array"
+                    "items":
+                      "type": "string"
+                      "description": "Hex-encoded transaction signature. After hexadecimal decoding, including removal of an optional lowercase `0x` prefix and left-padding of an odd number of hexadecimal digits, each supplied signature must be 65\u201368 bytes; otherwise broadcast returns `SIGERROR`."
+                    "description": "Transaction signatures supplied for broadcast."
             "required":
               - "raw_data"
     "x-overlay-derived": true
     "x-source-refs":
       - "framework/src/main/java/org/tron/core/services/http/BroadcastServlet.java"
       - "framework/src/main/java/org/tron/core/services/http/Util.java"
+      - "framework/src/main/java/org/tron/core/Wallet.java"
+      - "crypto/src/main/java/org/tron/common/crypto/SignUtils.java"
+      - "common/src/main/java/org/tron/core/Constant.java"
       - "protocol/src/main/protos/core/Tron.proto#Transaction"

--- a/docs/developers/network.md
+++ b/docs/developers/network.md
@@ -26,13 +26,19 @@ The architecture diagram of TRON is as follows:
 As the most fundamental module of TRON, the P2P network directly determines the stability of the entire blockchain network. The network module can be divided into the following four parts according to the function:
 
 * Node Discovery
-* Node Connection
+* [Node Connection](#peer-connection-management)
 * [Block Synchronization](#block-synchronization)
 * [Block and Transaction Broadcast](#block-and-transaction-broadcast)
 
 The underlying implementations of **Node Discovery** and **Node Connection** have been extracted from the java-tron repository into a standalone external dependency, [`io.github.tronprotocol:libp2p`](https://github.com/tronprotocol/libp2p). This library is responsible for low-level node discovery (based on the Kademlia algorithm) and connection transport, and it adds capabilities such as DNS-based node discovery. The TRON protocol layer above it — including the P2P_HELLO handshake, P2P_PING/P2P_PONG keep-alive, peer business-state management, message dispatch, synchronization, and broadcast — is still implemented in java-tron's `core/net`, which integrates with libp2p through `TronNetService`. For the low-level discovery and connection implementation details, please refer to the libp2p repository; they are no longer covered in this document.
 
 **Block Synchronization** and **Block and Transaction Broadcast** are still implemented in java-tron's `core/net`, and are introduced separately below.
+
+## Peer Connection Management
+
+When random peer disconnection is enabled and the node has reached its maximum number of connections, java-tron periodically frees a connection slot so that it can discover potentially better peers. Trusted peers are never selected. In the primary selection path, peers that are synchronizing in either direction are also excluded. If at least three eligible broadcast peers remain, java-tron sorts them by `blockRcvTime`—the time at which each peer last supplied a successfully processed block—and keeps the older half as candidates. It then makes a weighted random selection based on `lastInteractiveTime`, so peers that have been inactive for longer are more likely to be disconnected. This prevents a full connection table from being occupied indefinitely by peers that contribute little recent block data.
+
+For received block inventory, `lastInteractiveTime` is updated only when a peer announces a block above the local head. Stale block inventory therefore cannot make a peer appear recently active.
 
 ## Block Synchronization
 
@@ -45,6 +51,14 @@ Node A sends an `SYNC_BLOCK_CHAIN` message to peer node B to announce the blockc
 After node A receives the `BLOCK_CHAIN_INVENTORY` message, it gets the missing block id, and sends a `FETCH_INV_DATA` message to node B asynchronously to request the missing block, up to 100 blocks at a time. If there are still blocks that need to be synchronized (that is, the remain_num in the `BLOCK_CHAIN_INVENTORY` message is greater than 0), a new round of block synchronization process will be triggered.
 
 After node B receives the `FETCH_INV_DATA` message from node A, it sends the block to node A through the `BLOCK` message. After node A receives the `BLOCK` message, it asynchronously processes the block.
+
+### Synchronization Limits and Resource Control
+
+An inbound `SYNC_BLOCK_CHAIN` message must contain at least one block ID and may contain no more than 30 block IDs. A message outside these bounds is treated as an invalid protocol message. The separate `BLOCK_CHAIN_INVENTORY` response can still carry up to 2000 missing block IDs, as described above.
+
+To reduce retained heap usage during catch-up, java-tron stores pending synchronization blocks in its queues as a block ID plus serialized bytes instead of retaining a parsed `BlockCapsule`. The bytes are parsed again when the queued block is ready to be processed.
+
+`node.maxPendingBlockSize` provides a global budget for new forward-progress synchronization requests. The available budget accounts for blocks requested across active peers, blocks just received, and blocks waiting to be processed. Retry requests for heights at or below the highest previously requested height may bypass this budget to avoid a synchronization deadlock, so the setting is not a strict upper bound on all in-flight blocks. Its default value is `500`; values outside the supported range of `50` to `2000` are clamped to the nearest bound.
 
 ### Blockchain Summary and List of Missing Blocks
 Below will take several different block synchronization scenarios as examples to illustrate the generation of the blockchain summary and the lost block ID list. 
@@ -91,6 +105,20 @@ The types of messages involved include:
 Node A sends the transaction or block to be broadcast to Node B via the `INVENTORY` list message. After node B receives the `INVENTORY` list message, it needs to check the status of the peer node, and if it can receive the message, it puts the blocks/transactions in the list into the "to be fetched queue" `invToFetch`. If it is a block list, it will also trigger the "get block & transaction task" immediately to send a `FETCH_INV_DATA` message to node A to get the block & transaction.
 
 After node A receives the `FETCH_INV_DATA` message, it will check whether an "INVENTORY" message has been sent to the peer. If it has been sent, it will send a transaction or block message to node B according to the list data. After node B receives the transaction or block message, it processes the message and triggers the forwarding process.
+
+### Inbound Validation and Backpressure
+
+Before accepting or forwarding broadcast data, java-tron applies validation and resource controls at the P2P boundary:
+
+| Check | Behavior |
+|---|---|
+| Inventory type and duplicates | The inventory type in an `INVENTORY` or `FETCH_INV_DATA` message must be either `TRX` or `BLOCK`. Duplicate hashes within either message and duplicate transactions within a `TRXS` message cause the message to be rejected and the sending peer to be disconnected with `BAD_PROTOCOL`. |
+| Transaction inventory rate | The number of transaction IDs announced by each peer is limited by `node.maxTps`, which defaults to `1000` IDs per second. The limit is evaluated over a 10-second window and includes the IDs in the current message. A transaction `INVENTORY` message that would exceed the projected window limit is dropped. |
+| Block inventory rate | Block inventory from each peer is limited by `node.maxBlockInvPerSecond`. The limit is enforced over a rolling 10-second window. With the default value of `10`, up to `100` block IDs are allowed in the window, including IDs in the current message. Values below `1` are raised to `1`. A block `INVENTORY` message that would exceed the window limit is dropped. |
+| Transaction backpressure | If the transaction handling queues and transaction cache exceed `node.maxTrxCacheSize`, new transaction inventory announcements are dropped until capacity becomes available. The default is `50000`; values below `2000` are raised to `2000`. |
+| Signature length | Every signature in a transaction received over P2P, as well as the signature in a fast-forward `HelloMessage`, must be between `65` and `68` bytes, inclusive. A transaction containing a signature outside this range is treated as a bad transaction; an incorrectly sized `HelloMessage` signature is rejected before signature verification. |
+| Block validation | An announced block is validated before it is re-broadcast. An invalid Merkle root or block signature causes the sending peer to be disconnected with the `BAD_BLOCK` reason. |
+| Protobuf normalization | For a received `Block`, java-tron removes unknown protobuf fields from both the block itself and its `BlockHeader` before processing or forwarding it. |
 
 ## Summary
 This article introduces the P2P network, the lowest level module of TRON. Node discovery and node connection have been extracted into the external libp2p dependency and are only briefly located here; block synchronization and the process of block and transaction broadcasting, which remain in java-tron's `core/net`, are introduced in detail. I hope that reading this article can help developers to further understand and develop java-tron network-related modules.

--- a/docs/using_javatron/installing_javatron.md
+++ b/docs/using_javatron/installing_javatron.md
@@ -246,6 +246,31 @@ Starting from version 4.8.1, `SolidityNode.jar` is no longer provided. Instead, 
 java -Xmx24g -XX:+UseConcMarkSweepGC -jar build/libs/FullNode.jar --solidity -c framework/src/main/resources/config.conf
 ```
 
+#### Configuring Conditional Shutdown
+
+SolidityNode supports the same `node.shutdown` conditions as FullNode. You can configure the node to shut down after it persists a block matching a target time or height, or after it synchronizes a specified number of blocks from its startup height.
+
+Configure exactly one of `BlockTime`, `BlockHeight`, or `BlockCount`. For example:
+
+```properties
+node.shutdown = {
+  # Quartz cron expression matched against the persisted block header time
+  BlockTime = "54 59 08 * * ?"
+
+  # Alternatively, configure exactly one of the following:
+  # BlockHeight = 33350800
+  # BlockCount = 12
+}
+```
+
+| Parameter | Description |
+|---|---|
+| `BlockTime` | A Quartz cron expression. The node shuts down after persisting a block whose header timestamp satisfies the expression. |
+| `BlockHeight` | The target persisted block height at which the node shuts down. Use a positive value that is not lower than the node's current head height. A negative value is treated as unset. A positive value below the current head causes startup to fail. A value of `0` is accepted but normally does not establish an active shutdown target; if the current head is also `0` and `--p2p-disable` is not enabled, the node exits immediately. Do not use `0` as a shutdown height. |
+| `BlockCount` | The number of additional blocks to synchronize after startup before shutting down. Use a value greater than `0`. A value of `0` causes startup to fail, while a negative value is treated as unset. |
+
+If more than one shutdown condition is enabled, or `BlockTime` is invalid, parameter initialization fails and the node does not start.
+
 
 ### Starting a Block Production Node
 


### PR DESCRIPTION
## Summary

- align the P2P network documentation with java-tron v4.8.2 behavior, including peer rotation, synchronization limits, inventory backpressure, signature-length checks, block validation, and protobuf normalization
- document conditional node shutdown controls for block time, height, and count targets
- document the 65–68 byte signature requirement on transaction broadcast paths
- synchronize the endpoint OpenAPI fragments and bundled OpenAPI definition

## Why

java-tron v4.8.2 adds and tightens several network-boundary and operational controls. The documentation and machine-readable API definitions need to describe the implemented limits, exceptions, and error behavior accurately.

## Impact

Node operators receive clearer configuration and shutdown guidance, while API and protocol users can identify the signature and synchronization constraints enforced by java-tron.

## Validation

- `mkdocs build --strict`
- OpenAPI 3.1 validation
- YAML parsing and fragment-to-bundle consistency checks
- `git diff --check`
