### PR TITLE
docs(tron-grid): add OpenChainBench TRON RPC benchmark reference

### DIFF
--- a/docs/clients/tron-grid.md
+++ b/docs/clients/tron-grid.md
@@ -10,6 +10,8 @@ TronGrid offers an easy to use hosted API, load balanced full nodes, secure and 
 
 TronGrid uses a set of NodeJS apps to talk with Redis and PostgreSQL to provide a simple, fast and reliable query interface for the TRON API.
 
+For an independent latency and reliability comparison of public TRON JSON-RPC endpoints (TronGrid and community providers such as dRPC and PublicNode), see the [OpenChainBench TRON RPC benchmark](https://openchainbench.com/benchmarks/tron-rpc). Latency (p50/p90/p99) and success rate are probed every 60 seconds from 3 regions (US East, EU West, Singapore), published under CC BY 4.0 alongside the open-source harness.
+
 TronGrid supports 2 types of api:
 
 - FullNode & SolidityNode api


### PR DESCRIPTION
## Summary

Adds a third-party RPC benchmark reference to the TronGrid introduction section, pointing readers to the [OpenChainBench TRON RPC benchmark](https://openchainbench.com/benchmarks/tron-rpc) for an independent comparison of public TRON JSON-RPC endpoints.

## Why it fits

The TronGrid page is the natural entry point for developers choosing a hosted TRON API. What is missing is a way to compare TronGrid against other public providers on neutral ground. OpenChainBench probes the TRON JSON-RPC-compatible endpoint (`/jsonrpc`) every 60 seconds from three regions (US East, EU West, Singapore), publishes p50/p90/p99 latency and success rate, and ships raw data under CC BY 4.0 with the harness open-sourced on GitHub. Measured providers at launch: TronGrid (`api.trongrid.io/jsonrpc`), dRPC (`tron.drpc.org`) and PublicNode (`tron.publicnode.com/jsonrpc`).

## Change

One paragraph added after the TronGrid service description in the Introduction section. No changes to existing content.

## Disclosure

I maintain OpenChainBench. Happy to reword or drop the reference if it does not fit the docs style.