### PR TITLE
align wallet-cli docs with v4.10.0 and restructure wallet-cli docs

### DIFF
--- a/docs/clients/wallet-cli/accounts.md
+++ b/docs/clients/wallet-cli/accounts.md
@@ -16,7 +16,7 @@ once it is activated, e.g. by receiving TRX or via this command.)
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile create-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile create-account --address TXyz...
     ```
 
     - `--address` (required) — the address to activate.
@@ -33,7 +33,7 @@ once it is activated, e.g. by receiving TRX or via this command.)
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-account --name "my account"
+    java -jar java/build/libs/wallet-cli.jar --network nile update-account --name "my account"
     ```
 
     - `--name` (required) — the new account name.
@@ -52,7 +52,7 @@ Sets a unique, human-readable account ID for the account.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile set-account-id --id myaccountid
+    java -jar java/build/libs/wallet-cli.jar --network nile set-account-id --id myaccountid
     ```
 
     - `--id` (required) — the account ID to set.
@@ -71,7 +71,7 @@ Sets a unique, human-readable account ID for the account.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account --address TXyz...
     ```
 
     - `--address` (required). No auth required.
@@ -87,7 +87,7 @@ Sets a unique, human-readable account ID for the account.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account-by-id --id myaccountid
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account-by-id --id myaccountid
     ```
 
     - `--id` (required). No auth required.
@@ -105,7 +105,7 @@ Prints the address of the active/logged-in wallet.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar get-address
+    java -jar java/build/libs/wallet-cli.jar get-address
     ```
 
     Requires auth (it reports the active wallet's address).
@@ -122,10 +122,10 @@ Prints the address of the active/logged-in wallet.
 
     ```bash
     # Balance of an explicit address (no auth needed)
-    java -jar build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
 
     # Balance of the active wallet (requires auth)
-    java -jar build/libs/wallet-cli.jar --network nile get-balance
+    java -jar java/build/libs/wallet-cli.jar --network nile get-balance
     ```
 
     - `--address` (optional). If provided, no auth is required; if omitted, the active wallet's
@@ -156,7 +156,7 @@ replaces the account's permission set with the one you supply.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-account-permission \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-account-permission \
       --owner TXyz... --permissions '<permission-json>'
     ```
 
@@ -210,7 +210,7 @@ The permission JSON has the following shape (keys, thresholds, and weighted sign
 
 - `threshold` is the total signer weight required for the permission to authorize an action.
 - `operations` (active permissions only) is a 32-byte hex bitmap selecting which contract/operation
-  types the permission may perform. The example above matches the 4.9.7 default active-permission
-  bitmap: it excludes disabled operation 51 (`ShieldedTransferContract`) while retaining active
-  operations such as 49 and 52.
+  types the permission may perform. The example above matches the default active-permission bitmap:
+  it excludes disabled operation 51 (`ShieldedTransferContract`) while retaining active operations
+  such as 49 and 52.
 - `witness_permission` is only relevant for super-representative accounts.

--- a/docs/clients/wallet-cli/gasfree.md
+++ b/docs/clients/wallet-cli/gasfree.md
@@ -16,7 +16,7 @@ current nonce/balance details used when building a transfer.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile gas-free-info --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile gas-free-info --address TXyz...
     ```
 
     - `--address` (optional) — defaults to the current wallet's address. With `--address`, no auth
@@ -39,7 +39,7 @@ the GasFree relayer rather than in TRX. In JSON mode the response `data` include
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile gas-free-transfer \
+    java -jar java/build/libs/wallet-cli.jar --network nile gas-free-transfer \
       --to TXyz... --amount 1000000
     ```
 
@@ -59,7 +59,7 @@ Looks up the status of a previously submitted GasFree transfer by its trace/requ
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile gas-free-trace --id <traceId>
+    java -jar java/build/libs/wallet-cli.jar --network nile gas-free-trace --id <traceId>
     ```
 
     - `--id` (required). No auth required.

--- a/docs/clients/wallet-cli/governance.md
+++ b/docs/clients/wallet-cli/governance.md
@@ -16,7 +16,7 @@ Registers the account as a witness (SR candidate).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile create-witness --url https://my-sr.example
+    java -jar java/build/libs/wallet-cli.jar --network nile create-witness --url https://my-sr.example
     ```
 
     - `--url` (required). `--owner`, `--multi` (optional).
@@ -34,7 +34,7 @@ Updates the witness's URL.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-witness --url https://my-sr.example
+    java -jar java/build/libs/wallet-cli.jar --network nile update-witness --url https://my-sr.example
     ```
 
     - `--url` (required). `--owner`, `--multi` (optional).
@@ -50,7 +50,7 @@ Updates the witness's URL.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-witnesses
+    java -jar java/build/libs/wallet-cli.jar --network nile list-witnesses
     ```
 
 === "REPL"
@@ -75,7 +75,7 @@ replaces your previous votes.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile vote-witness \
+    java -jar java/build/libs/wallet-cli.jar --network nile vote-witness \
       --votes "TWitnessA... 100 TWitnessB... 50"
     ```
 
@@ -97,7 +97,7 @@ Withdraws accumulated voting/witness rewards to the spendable balance.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile withdraw-balance
+    java -jar java/build/libs/wallet-cli.jar --network nile withdraw-balance
     ```
 
     - `--owner`, `--multi` (optional).
@@ -115,7 +115,7 @@ Shows the currently claimable reward for an address.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-reward --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-reward --address TXyz...
     ```
 
     - `--address` (required). No auth required.
@@ -133,7 +133,7 @@ Shows a witness's brokerage percentage (the share of rewards the SR keeps).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-brokerage --address TWitness...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-brokerage --address TWitness...
     ```
 
     - `--address` (required). No auth required.
@@ -151,7 +151,7 @@ Sets the witness's brokerage percentage (0–100).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-brokerage --brokerage 20
+    java -jar java/build/libs/wallet-cli.jar --network nile update-brokerage --brokerage 20
     ```
 
     - `--brokerage` (required, 0–100). `--owner`, `--multi` (optional).
@@ -174,7 +174,7 @@ effect when enough approvals are gathered. Each proposal is a set of `parameter_
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile create-proposal \
+    java -jar java/build/libs/wallet-cli.jar --network nile create-proposal \
       --parameters "9 1 18 1"
     ```
 
@@ -192,7 +192,7 @@ effect when enough approvals are gathered. Each proposal is a set of `parameter_
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile approve-proposal --id 42 --approve true
+    java -jar java/build/libs/wallet-cli.jar --network nile approve-proposal --id 42 --approve true
     ```
 
     - `--id` (required), `--approve` (required, `true` to add approval / `false` to withdraw it).
@@ -213,7 +213,7 @@ Cancels a proposal (proposer only).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile delete-proposal --id 42
+    java -jar java/build/libs/wallet-cli.jar --network nile delete-proposal --id 42
     ```
 
     - `--id` (required). `--owner`, `--multi` (optional).
@@ -229,7 +229,7 @@ Cancels a proposal (proposer only).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-proposals
+    java -jar java/build/libs/wallet-cli.jar --network nile list-proposals
     ```
 
 === "REPL"
@@ -243,7 +243,7 @@ Cancels a proposal (proposer only).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-proposals-paginated --offset 0 --limit 20
+    java -jar java/build/libs/wallet-cli.jar --network nile list-proposals-paginated --offset 0 --limit 20
     ```
 
     - `--offset` (required), `--limit` (required).
@@ -259,7 +259,7 @@ Cancels a proposal (proposer only).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-proposal --id 42
+    java -jar java/build/libs/wallet-cli.jar --network nile get-proposal --id 42
     ```
 
     - `--id` (required).

--- a/docs/clients/wallet-cli/index.md
+++ b/docs/clients/wallet-cli/index.md
@@ -1,30 +1,27 @@
 # wallet-cli
 
 `wallet-cli` is a command-line wallet for the TRON network; its official repository is
-[tronprotocol/wallet-cli](https://github.com/tronprotocol/wallet-cli). It manages keys and accounts locally
-and talks to a TRON node primarily over gRPC (through the
-[Trident SDK](https://github.com/tronprotocol/trident)) to query chain data and build, sign, and
-broadcast transactions. A few features (such as GasFree fee-delegated transfers) instead call the
-relevant service over HTTP.
+[tronprotocol/wallet-cli](https://github.com/tronprotocol/wallet-cli). It manages keys and accounts
+locally and connects to TRON services to query chain data and build, sign, and broadcast
+transactions.
 
-It offers three ways to drive it:
+The repository provides two implementations:
 
-- **Java Interactive (REPL) mode** — a human-friendly shell with tab completion and interactive
-  prompts. Best for manual exploration and day-to-day wallet management.
-- **Java Standard CLI mode** — a non-interactive, scriptable interface with deterministic exit codes
-  and optional JSON output. Best for automation and scripts that use the Java JAR.
-- **TypeScript / npm CLI** — a separate Node.js-based CLI introduced in 4.9.7 and published as
-  `@tron-walletcli/wallet-cli`. It uses grouped commands such as `tx send` and `account balance`,
-  and is designed for automation, CI/CD, and AI agents.
+- **[Java CLI](java-cli.md)** — the original, full-featured implementation. It provides an
+  interactive REPL for people and a non-interactive Standard CLI for scripts using the Java JAR.
+- **[TypeScript / npm CLI](typescript-cli.md)** — an agent-first Node.js implementation published as
+  `@tron-walletcli/wallet-cli`, with grouped commands, deterministic exit codes, and structured JSON
+  output.
 
-The command reference pages below focus on the Java JAR's REPL and Standard CLI modes. For the
-Node.js command surface, see [TypeScript / npm CLI](typescript-cli.md). Use the tabs below to compare
-the same account query across the three entry points:
+## Compare entry points
+
+Each interface can query account data. The Java CLI accepts an arbitrary address, while the
+TypeScript CLI operates on an account already stored in its local wallet:
 
 === "Java Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account --address TXyz...
     ```
 
 === "Java REPL"
@@ -36,180 +33,18 @@ the same account query across the three entry points:
 === "TypeScript / npm CLI"
 
     ```bash
-    wallet-cli account info --network tron:nile --account TXyz...
+    wallet-cli account info --network tron:nile
     ```
 
-## Build
+    This uses the active account. Pass `--account` with an account id, label, or address already
+    present in the local wallet to select a different stored account.
 
-`wallet-cli` is built with Gradle and requires **Java 8**.
+## Choose an implementation
 
-```bash
-# Build the project (also generates protobuf sources into src/main/gen/)
-./gradlew build
+| Implementation | Command style | Best suited for |
+|----------------|---------------|-----------------|
+| [Java CLI](java-cli.md) | Interactive commands such as `GetAccount`, or Standard CLI commands such as `get-account` | The complete TRON wallet feature set, manual operation, and Java JAR integrations |
+| [TypeScript / npm CLI](typescript-cli.md) | Grouped commands such as `account info` and `tx send` | Automation, CI/CD, structured JSON integrations, and AI agents |
 
-# Build the fat JAR (output: build/libs/wallet-cli.jar)
-./gradlew shadowJar
-```
-
-After `shadowJar`, you can run the wallet from the produced JAR:
-
-```bash
-java -jar build/libs/wallet-cli.jar
-```
-
-## Run
-
-### Interactive (REPL) mode
-
-Launch the interactive shell with no command. Either of these works:
-
-```bash
-./gradlew run
-# or, from the built JAR:
-java -jar build/libs/wallet-cli.jar
-```
-
-You then type commands at the prompt (for example `Login`, `GetBalance`, `SendCoin ...`). Command
-names are case-insensitive and support tab completion. Type `Help` to list commands, or
-`Help <Command>` for details on one command.
-
-### Standard CLI mode
-
-Pass a command (and its options) on the command line. The process runs the single command, prints
-the result, and exits:
-
-```bash
-java -jar build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
-java -jar build/libs/wallet-cli.jar --output json --network nile get-account --address TXyz...
-```
-
-Standard CLI command names use kebab-case (`get-account`, `send-coin`); most commands also accept a
-no-dash alias (`getaccount`, `sendcoin`). Not every command registers one — the `alias-*` commands,
-for example, are only available in their dashed form.
-
-There is also a `help` command for per-command usage:
-
-```bash
-java -jar build/libs/wallet-cli.jar help --command send-coin
-```
-
-## Global options (Standard CLI)
-
-Execution-modifier global options are parsed by `GlobalOptions` and may appear either **before or
-after** the command name. Top-level mode selectors have stricter placement rules, as described
-below.
-
-| Option | Values | Description |
-|--------|--------|-------------|
-| `--network` | `main`, `nile`, `shasta`, `custom` | Select the network to connect to. |
-| `--grpc-endpoint` | `host:port` | Override the gRPC endpoint (used with `--network custom`). |
-| `--output` | `text` (default), `json` | Output format. |
-| `--wallet` | name or path | Select a specific wallet keystore by name or path. |
-| `--quiet` | flag | Suppress non-essential informational output. |
-| `--verbose` | flag | Enable debug logging. (Conflicts with `--quiet`.) |
-| `--password-stdin` | flag | Read the wallet password from stdin (overrides `MASTER_PASSWORD`). |
-| `--interactive` | flag | Launch the interactive REPL instead of running a command. |
-| `--help`, `-h` | flag | Show global help, or help for the named command. (The `help --command <name>` command does the same.) |
-| `--version` | flag | Print version information. |
-
-Notes:
-
-- The execution modifiers `--network`, `--grpc-endpoint`, `--output`, `--wallet`, `--quiet`,
-  `--verbose`, and `--password-stdin` are recognized before or after the command name.
-- The top-level mode selectors `--version` and `--interactive` must appear before the command name.
-  After a command, they are treated as command-local arguments instead.
-- `--help` and `-h` before the command request global help; after the command they request help for
-  that command.
-- Valued global options (`--output`, `--network`, `--wallet`, and `--grpc-endpoint`) accept their
-  value either as the next token (`--network nile`) or inline (`--network=nile`).
-- Options that take a value cannot be repeated, and unknown global options are rejected.
-
-## Authentication (Standard CLI)
-
-Standard CLI mode is non-interactive, so it never prompts for a password. Commands that build and
-sign a transaction (marked **requires auth** in this documentation) authenticate automatically:
-
-1. The wallet password is read from the `MASTER_PASSWORD` environment variable, or from **stdin**
-   when `--password-stdin` is passed (stdin takes precedence).
-2. The keystore is loaded from the `Wallet/` directory. Use `--wallet <name|path>` to pick a
-   specific wallet, or set an **active wallet** with `set-active-wallet` (see
-   [Wallet Management](wallet-management.md)).
-
-Most read-only query commands do not require authentication. The exceptions are queries that act on
-the current wallet: `get-address` always requires auth, and `get-balance` / `get-usdt-balance` /
-`gas-free-info` require auth when `--address` is omitted (see [Queries](query.md) and
-[GasFree](gasfree.md)).
-
-```bash
-export MASTER_PASSWORD='your-wallet-password'
-java -jar build/libs/wallet-cli.jar --network nile send-coin --to TXyz... --amount 1000000
-```
-
-The REPL handles authentication differently: you log in interactively with `Login` / `LoginAll`
-and the session stays unlocked. See [Wallet Management](wallet-management.md).
-
-## JSON output and exit codes (Standard CLI)
-
-With `--output json`, every command emits a single JSON envelope on stdout.
-
-Success:
-
-```json
-{
-  "success": true,
-  "data": { }
-}
-```
-
-Error:
-
-```json
-{
-  "success": false,
-  "error": "execution_error",
-  "message": "human-readable explanation"
-}
-```
-
-Additional rules:
-
-- Commands that broadcast a transaction include the transaction id as `txid` in `data`
-  (single-signature broadcasts only).
-- `deploy-contract` includes the deployed `contract_address` in `data`.
-- When an alias is resolved for an option, the envelope includes a `meta.resolved` array describing
-  the resolution (see the alias system in [Wallet Management](wallet-management.md)).
-
-Exit codes:
-
-| Code | Meaning |
-|------|---------|
-| `0` | Success. |
-| `1` | Execution error (`"error": "execution_error"` and others). |
-| `2` | Usage error (`"error": "usage_error"` — bad flags, missing required option, etc.). |
-
-This makes the standard CLI safe to drive from scripts: check the exit code, and parse the single
-JSON object from stdout.
-
-## Networks and configuration
-
-The default node endpoints for each network, plus other defaults, live in
-`src/main/resources/config.conf` (HOCON format). The `--network` flag selects among `main`, `nile`
-(testnet), `shasta` (testnet), and `custom`. For `custom`, provide the endpoint with
-`--grpc-endpoint host:port`.
-
-In the REPL, use `SwitchNetwork` to change networks and `CurrentNetwork` to see the active one.
-
-## Command reference
-
-Commands are grouped by domain:
-
-- [Wallet Management](wallet-management.md) — create/import/export wallets, login, backup, lock,
-  active wallet, aliases.
-- [Accounts](accounts.md) — on-chain account creation and updates, balances, permissions.
-- [Staking & Resources](staking.md) — freeze/unfreeze (v1 & v2), resource delegation, rewards.
-- [Transactions](transactions.md) — transfer TRX/assets/USDT, multi-signature signing, broadcast.
-- [Smart Contracts](smart-contracts.md) — deploy, trigger, constant calls, energy estimation.
-- [TRC-10 Assets](trc10.md) — issue, update, participate, transfer, and query TRC-10 tokens.
-- [Governance](governance.md) — witnesses, voting, proposals, brokerage, reward withdrawal.
-- [GasFree](gasfree.md) — gas-free (sponsored) USDT transfers.
-- [Queries](query.md) — blocks, transactions, chain parameters, prices, nodes, and utilities.
+The two implementations have separate installation and runtime requirements. Continue with the
+[Java CLI overview](java-cli.md) or the [TypeScript / npm CLI overview](typescript-cli.md).

--- a/docs/clients/wallet-cli/java-cli.md
+++ b/docs/clients/wallet-cli/java-cli.md
@@ -1,0 +1,188 @@
+# Java CLI
+
+The Java implementation of `wallet-cli` provides two entry points:
+
+- **Interactive (REPL) mode** — a human-friendly shell with tab completion and interactive prompts.
+- **Standard CLI mode** — a non-interactive interface with deterministic exit codes and optional
+  JSON output.
+
+Both use the same Java JAR and together expose the Java implementation's feature surface, although
+some commands are available in only one mode. For the npm-based implementation, see
+[TypeScript / npm CLI](typescript-cli.md).
+
+## Build
+
+The Java implementation is located in the repository's `java/` directory. It is built with Gradle
+and requires **Java 8**. The commands below keep the working directory at the repository root so the
+paths used throughout this section stay consistent.
+
+```bash
+git clone https://github.com/tronprotocol/wallet-cli.git
+cd wallet-cli
+
+# Build the project and the fat JAR
+./java/gradlew -p java build shadowJar
+```
+
+After `shadowJar`, you can run the wallet from the produced JAR:
+
+```bash
+java -jar java/build/libs/wallet-cli.jar
+```
+
+## Run
+
+### Interactive (REPL) mode
+
+Launch the interactive shell with no command. Either of these works:
+
+```bash
+./java/gradlew -p java run
+# or, from the built JAR:
+java -jar java/build/libs/wallet-cli.jar
+```
+
+You then type commands at the prompt (for example `Login`, `GetBalance`, `SendCoin ...`). Command
+names are case-insensitive and support tab completion. Type `Help` to list commands, or
+`Help <Command>` for details on one command.
+
+### Standard CLI mode
+
+Pass a command (and its options) on the command line. The process runs the single command, prints
+the result, and exits:
+
+```bash
+java -jar java/build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
+java -jar java/build/libs/wallet-cli.jar --output json --network nile get-account --address TXyz...
+```
+
+Standard CLI command names use kebab-case (`get-account`, `send-coin`); most commands also accept a
+no-dash alias (`getaccount`, `sendcoin`). Not every command registers one — the `alias-*` commands,
+for example, are only available in their dashed form.
+
+There is also a `help` command for per-command usage:
+
+```bash
+java -jar java/build/libs/wallet-cli.jar help --command send-coin
+```
+
+## Global options (Standard CLI)
+
+Execution-modifier global options are parsed by `GlobalOptions` and may appear either **before or
+after** the command name. Top-level mode selectors have stricter placement rules, as described
+below.
+
+| Option | Values | Description |
+|--------|--------|-------------|
+| `--network` | `main`, `nile`, `shasta`, `custom` | Select the network to connect to. |
+| `--grpc-endpoint` | `host:port` | Override the gRPC endpoint (used with `--network custom`). |
+| `--output` | `text` (default), `json` | Output format. |
+| `--wallet` | name or path | Select a specific wallet keystore by name or path. |
+| `--quiet` | flag | Suppress non-essential informational output. |
+| `--verbose` | flag | Enable debug logging. (Conflicts with `--quiet`.) |
+| `--password-stdin` | flag | Read the wallet password from stdin (overrides `MASTER_PASSWORD`). |
+| `--interactive` | flag | Launch the interactive REPL instead of running a command. |
+| `--help`, `-h` | flag | Show global help, or help for the named command. (The `help --command <name>` command does the same.) |
+| `--version` | flag | Print version information. |
+
+Notes:
+
+- The execution modifiers `--network`, `--grpc-endpoint`, `--output`, `--wallet`, `--quiet`,
+  `--verbose`, and `--password-stdin` are recognized before or after the command name.
+- The top-level mode selectors `--version` and `--interactive` must appear before the command name.
+  After a command, they are treated as command-local arguments instead.
+- `--help` and `-h` before the command request global help; after the command they request help for
+  that command.
+- Valued global options (`--output`, `--network`, `--wallet`, and `--grpc-endpoint`) accept their
+  value either as the next token (`--network nile`) or inline (`--network=nile`).
+- Options that take a value cannot be repeated, and unknown global options are rejected.
+
+## Authentication (Standard CLI)
+
+Standard CLI mode is non-interactive, so it never prompts for a password. Commands that build and
+sign a transaction (marked **requires auth** in this documentation) authenticate automatically:
+
+1. The wallet password is read from the `MASTER_PASSWORD` environment variable, or from **stdin**
+   when `--password-stdin` is passed (stdin takes precedence).
+2. The keystore is loaded from the `Wallet/` directory. Use `--wallet <name|path>` to pick a
+   specific wallet, or set an **active wallet** with `set-active-wallet` (see
+   [Wallet Management](wallet-management.md)).
+
+Most read-only query commands do not require authentication. The exceptions are queries that act on
+the current wallet: `get-address` always requires auth, and `get-balance` / `get-usdt-balance` /
+`gas-free-info` require auth when `--address` is omitted (see [Queries](query.md) and
+[GasFree](gasfree.md)).
+
+```bash
+export MASTER_PASSWORD='your-wallet-password'
+java -jar java/build/libs/wallet-cli.jar --network nile send-coin --to TXyz... --amount 1000000
+```
+
+The REPL handles authentication differently: you log in interactively with `Login` / `LoginAll`
+and the session stays unlocked. See [Wallet Management](wallet-management.md).
+
+## JSON output and exit codes (Standard CLI)
+
+With `--output json`, every command emits a single JSON envelope on stdout.
+
+Success:
+
+```json
+{
+  "success": true,
+  "data": { }
+}
+```
+
+Error:
+
+```json
+{
+  "success": false,
+  "error": "execution_error",
+  "message": "human-readable explanation"
+}
+```
+
+Additional rules:
+
+- Commands that broadcast a transaction include the transaction id as `txid` in `data`
+  (single-signature broadcasts only).
+- `deploy-contract` includes the deployed `contract_address` in `data`.
+- When an alias is resolved for an option, the envelope includes a `meta.resolved` array describing
+  the resolution (see the alias system in [Wallet Management](wallet-management.md)).
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. |
+| `1` | Execution error (`"error": "execution_error"` and others). |
+| `2` | Usage error (`"error": "usage_error"` — bad flags, missing required option, etc.). |
+
+This makes the standard CLI safe to drive from scripts: check the exit code, and parse the single
+JSON object from stdout.
+
+## Networks and configuration
+
+The default node endpoints for each network, plus other defaults, live in
+`java/src/main/resources/config.conf` (HOCON format). The `--network` flag selects among `main`,
+`nile` (testnet), `shasta` (testnet), and `custom`. For `custom`, provide the endpoint with
+`--grpc-endpoint host:port`.
+
+In the REPL, use `SwitchNetwork` to change networks and `CurrentNetwork` to see the active one.
+
+## Command reference
+
+Commands are grouped by domain:
+
+- [Wallet Management](wallet-management.md) — create/import/export wallets, login, backup, lock,
+  active wallet, aliases.
+- [Accounts](accounts.md) — on-chain account creation and updates, balances, permissions.
+- [Staking & Resources](staking.md) — freeze/unfreeze (v1 & v2), resource delegation, rewards.
+- [Transactions](transactions.md) — transfer TRX/assets/USDT, multi-signature signing, broadcast.
+- [Smart Contracts](smart-contracts.md) — deploy, trigger, constant calls, energy estimation.
+- [TRC-10 Assets](trc10.md) — issue, update, participate, transfer, and query TRC-10 tokens.
+- [Governance](governance.md) — witnesses, voting, proposals, brokerage, reward withdrawal.
+- [GasFree](gasfree.md) — gas-free (sponsored) USDT transfers.
+- [Queries](query.md) — blocks, transactions, chain parameters, prices, nodes, and utilities.

--- a/docs/clients/wallet-cli/query.md
+++ b/docs/clients/wallet-cli/query.md
@@ -21,7 +21,7 @@ Shows which network the client is currently connected to (`MAIN`, `NILE`, `SHAST
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile current-network
+    java -jar java/build/libs/wallet-cli.jar --network nile current-network
     ```
 
 === "REPL"
@@ -37,7 +37,7 @@ Returns the on-chain governance parameters and their current values.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-chain-parameters
+    java -jar java/build/libs/wallet-cli.jar --network nile get-chain-parameters
     ```
 
 === "REPL"
@@ -53,7 +53,7 @@ Returns the timestamp (ms) of the next maintenance period, when SR/voting change
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-next-maintenance-time
+    java -jar java/build/libs/wallet-cli.jar --network nile get-next-maintenance-time
     ```
 
 === "REPL"
@@ -69,7 +69,7 @@ Returns the historical bandwidth price schedule.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-bandwidth-prices
+    java -jar java/build/libs/wallet-cli.jar --network nile get-bandwidth-prices
     ```
 
 === "REPL"
@@ -85,7 +85,7 @@ Returns the historical energy price schedule.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-energy-prices
+    java -jar java/build/libs/wallet-cli.jar --network nile get-energy-prices
     ```
 
 === "REPL"
@@ -101,7 +101,7 @@ Returns the fee charged for attaching a memo to a transaction.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-memo-fee
+    java -jar java/build/libs/wallet-cli.jar --network nile get-memo-fee
     ```
 
 === "REPL"
@@ -119,7 +119,7 @@ Returns a block by number, or the latest block when no number is given.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block --number 1000000
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block --number 1000000
     ```
 
     - `--number` (optional) — block number; defaults to the latest block.
@@ -137,7 +137,7 @@ Returns a block by number, or the latest block when no number is given.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-id --id 00000000000f4240...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-id --id 00000000000f4240...
     ```
 
     - `--id` (required) — the block ID (hash).
@@ -155,7 +155,7 @@ Accepts either a block number or a block ID.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-id-or-num --value 1000000
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-id-or-num --value 1000000
     ```
 
     - `--value` (required) — a block number or block ID.
@@ -174,7 +174,7 @@ Accepts either a block number or a block ID.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-latest-num --count 5
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-latest-num --count 5
     ```
 
     - `--count` (required) — number of most-recent blocks to return.
@@ -192,7 +192,7 @@ Returns blocks in the half-open range `[start, end)`.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-limit-next \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-limit-next \
       --start 1000000 --end 1000005
     ```
 
@@ -209,7 +209,7 @@ Returns blocks in the half-open range `[start, end)`.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile \
+    java -jar java/build/libs/wallet-cli.jar --network nile \
       get-transaction-count-by-block-num --number 1000000
     ```
 
@@ -230,7 +230,7 @@ Returns the transaction body for a transaction ID.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-transaction-by-id --id <txid>
+    java -jar java/build/libs/wallet-cli.jar --network nile get-transaction-by-id --id <txid>
     ```
 
     - `--id` (required) — the transaction ID (hash).
@@ -249,7 +249,7 @@ logs. Use this to read the outcome of a state-changing contract call.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-transaction-info-by-id --id <txid>
+    java -jar java/build/libs/wallet-cli.jar --network nile get-transaction-info-by-id --id <txid>
     ```
 
     - `--id` (required).
@@ -279,7 +279,7 @@ Lists the peer nodes the connected node is aware of.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-nodes
+    java -jar java/build/libs/wallet-cli.jar --network nile list-nodes
     ```
 
 === "REPL"
@@ -297,7 +297,7 @@ Returns the USDT (TRC-20) balance of an address. Supported on `main`, `nile`, an
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-usdt-balance --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-usdt-balance --address TXyz...
     ```
 
     - `--address` (optional) — defaults to the current wallet's address.

--- a/docs/clients/wallet-cli/smart-contracts.md
+++ b/docs/clients/wallet-cli/smart-contracts.md
@@ -23,7 +23,7 @@ calls, energy estimation, and contract queries do not.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile deploy-contract \
+    java -jar java/build/libs/wallet-cli.jar --network nile deploy-contract \
       --name MyToken \
       --abi '[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"}, ...]' \
       --bytecode 608060405234801561001057600080fd5b50... \
@@ -55,7 +55,7 @@ calls, energy estimation, and contract queries do not.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile trigger-contract \
+    java -jar java/build/libs/wallet-cli.jar --network nile trigger-contract \
       --contract TContract... \
       --method "transfer(address,uint256)" \
       --params "TRecipient...,1000000" \
@@ -86,7 +86,7 @@ spent.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile trigger-constant-contract \
+    java -jar java/build/libs/wallet-cli.jar --network nile trigger-constant-contract \
       --contract TContract... \
       --method "balanceOf(address)" \
       --params "TAccount..."
@@ -110,7 +110,7 @@ Estimates the energy a contract call would consume.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile estimate-energy \
+    java -jar java/build/libs/wallet-cli.jar --network nile estimate-energy \
       --contract TContract... \
       --method "transfer(address,uint256)" \
       --params "TRecipient...,1000000"
@@ -145,7 +145,7 @@ Create2 address code salt
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-setting \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-setting \
       --contract TContract... --consume-user-resource-percent 50
     ```
 
@@ -163,7 +163,7 @@ Create2 address code salt
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-energy-limit \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-energy-limit \
       --contract TContract... --origin-energy-limit 10000000
     ```
 
@@ -183,7 +183,7 @@ Removes the ABI stored on-chain for a contract.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile clear-contract-abi --contract TContract...
+    java -jar java/build/libs/wallet-cli.jar --network nile clear-contract-abi --contract TContract...
     ```
 
     - `--contract` (required). `--owner`, `--multi` (optional).
@@ -203,7 +203,7 @@ Returns the contract's bytecode and ABI.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-contract --address TContract...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-contract --address TContract...
     ```
 
     - `--address` (required).
@@ -221,7 +221,7 @@ Returns extended contract information (including runtime/code hash details).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-contract-info --address TContract...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-contract-info --address TContract...
     ```
 
     - `--address` (required).

--- a/docs/clients/wallet-cli/staking.md
+++ b/docs/clients/wallet-cli/staking.md
@@ -18,9 +18,9 @@ Resource codes used throughout:
 Code `2` (TRON_POWER) is network-gated for freeze/unfreeze commands:
 `FreezeBalance`/`UnfreezeBalance` (Stake 1.0), `FreezeBalanceV2`/`UnfreezeBalanceV2` (Stake 2.0),
 and their Standard CLI equivalents accept it only when the chain parameter
-`getAllowNewResourceModel` is enabled. If that chain parameter cannot be fetched, the 4.9.7 client
-fails open and lets the node validate the transaction at broadcast. Delegation commands (both modes)
-always accept only `0` or `1`; TRON_POWER is not delegatable.
+`getAllowNewResourceModel` is enabled. If that chain parameter cannot be fetched, the client fails
+open and lets the node validate the transaction at broadcast. Delegation commands (both modes) always
+accept only `0` or `1`; TRON_POWER is not delegatable.
 
 Amounts are in **SUN** (1 TRX = 1,000,000 SUN).
 
@@ -40,7 +40,7 @@ resource queries at the end of the page do not.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile freeze-balance \
+    java -jar java/build/libs/wallet-cli.jar --network nile freeze-balance \
       --amount 1000000 --duration 3 --resource 1
     ```
 
@@ -64,7 +64,7 @@ resource queries at the end of the page do not.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
+    java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
     ```
 
     - `--resource` (optional, `0`/`1`/`2`, default `0`). `2` is TRON_POWER and is allowed only when
@@ -88,7 +88,7 @@ No duration: staked TRX stays staked until you explicitly unstake it.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile freeze-balance-v2 \
+    java -jar java/build/libs/wallet-cli.jar --network nile freeze-balance-v2 \
       --amount 1000000 --resource 1
     ```
 
@@ -111,7 +111,7 @@ waiting period (see `withdraw-expire-unfreeze`).
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile unfreeze-balance-v2 \
+    java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-balance-v2 \
       --amount 1000000 --resource 1
     ```
 
@@ -133,7 +133,7 @@ Withdraws TRX whose unfreeze waiting period has elapsed, returning it to the spe
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile withdraw-expire-unfreeze
+    java -jar java/build/libs/wallet-cli.jar --network nile withdraw-expire-unfreeze
     ```
 
     - `--owner`, `--multi` (optional).
@@ -151,7 +151,7 @@ Cancels all pending v2 unstaking requests, returning that TRX to the staked stat
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile cancel-all-unfreeze-v2
+    java -jar java/build/libs/wallet-cli.jar --network nile cancel-all-unfreeze-v2
     ```
 
     - `--owner`, `--multi` (optional).
@@ -171,7 +171,7 @@ Lends staked bandwidth/energy to another account.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile delegate-resource \
+    java -jar java/build/libs/wallet-cli.jar --network nile delegate-resource \
       --amount 1000000 --resource 1 --receiver TXyz... --lock --lock-period 86400
     ```
 
@@ -195,7 +195,7 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile undelegate-resource \
+    java -jar java/build/libs/wallet-cli.jar --network nile undelegate-resource \
       --amount 1000000 --resource 1 --receiver TXyz...
     ```
 
@@ -215,7 +215,7 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account-net --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account-net --address TXyz...
     ```
 
     - `--address` (required).
@@ -231,7 +231,7 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account-resource --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account-resource --address TXyz...
     ```
 
     - `--address` (required).
@@ -247,9 +247,9 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-delegated-resource \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-delegated-resource \
       --from TFrom... --to TTo...
-    java -jar build/libs/wallet-cli.jar --network nile get-delegated-resource-v2 \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-delegated-resource-v2 \
       --from TFrom... --to TTo...
     ```
 
@@ -267,9 +267,9 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile \
+    java -jar java/build/libs/wallet-cli.jar --network nile \
       get-delegated-resource-account-index --address TXyz...
-    java -jar build/libs/wallet-cli.jar --network nile \
+    java -jar java/build/libs/wallet-cli.jar --network nile \
       get-delegated-resource-account-index-v2 --address TXyz...
     ```
 
@@ -287,7 +287,7 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-can-delegated-max-size \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-can-delegated-max-size \
       --owner TXyz... --type 1
     ```
 
@@ -306,7 +306,7 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-available-unfreeze-count --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-available-unfreeze-count --address TXyz...
     ```
 
     - `--address` (required).
@@ -322,7 +322,7 @@ Recalls previously delegated resources.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-can-withdraw-unfreeze-amount \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-can-withdraw-unfreeze-amount \
       --address TXyz... --timestamp 1700000000000
     ```
 

--- a/docs/clients/wallet-cli/transactions.md
+++ b/docs/clients/wallet-cli/transactions.md
@@ -14,7 +14,7 @@ together with `--multi`. Transfer commands require auth.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile send-coin \
+    java -jar java/build/libs/wallet-cli.jar --network nile send-coin \
       --to TXyz... --amount 1000000
     ```
 
@@ -33,7 +33,7 @@ together with `--multi`. Transfer commands require auth.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile transfer-asset \
+    java -jar java/build/libs/wallet-cli.jar --network nile transfer-asset \
       --to TXyz... --asset 1000001 --amount 100
     ```
 
@@ -53,7 +53,7 @@ Convenience command for transferring USDT (TRC-20). Supported on `main`, `nile`,
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile transfer-usdt \
+    java -jar java/build/libs/wallet-cli.jar --network nile transfer-usdt \
       --to TXyz... --amount 1000000
     ```
 
@@ -105,7 +105,7 @@ Submits a signed, hex-encoded transaction to the network.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile broadcast-transaction \
+    java -jar java/build/libs/wallet-cli.jar --network nile broadcast-transaction \
       --transaction 0a83010a02...
     ```
 

--- a/docs/clients/wallet-cli/trc10.md
+++ b/docs/clients/wallet-cli/trc10.md
@@ -16,7 +16,7 @@ during the sale.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile asset-issue \
+    java -jar java/build/libs/wallet-cli.jar --network nile asset-issue \
       --name MyToken --abbr MTK --total-supply 1000000000 \
       --trx-num 1 --ico-num 100 --precision 6 \
       --start-time 1700000000000 --end-time 1701000000000 \
@@ -46,7 +46,7 @@ Updates mutable parameters of a token you issued.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-asset \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-asset \
       --description "Updated" --url https://example.com \
       --new-limit 0 --new-public-limit 0
     ```
@@ -67,7 +67,7 @@ Buys a token during its ICO window by sending TRX to the issuer.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile participate-asset-issue \
+    java -jar java/build/libs/wallet-cli.jar --network nile participate-asset-issue \
       --to TIssuer... --asset 1000001 --amount 1000000
     ```
 
@@ -91,7 +91,7 @@ Unfreezes supply that was frozen at issuance, once its lock period has elapsed.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile unfreeze-asset
+    java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-asset
     ```
 
     - `--owner`, `--multi` (optional).
@@ -109,7 +109,7 @@ Unfreezes supply that was frozen at issuance, once its lock period has elapsed.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-by-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-by-account --address TXyz...
     ```
 
     - `--address` (required).
@@ -125,7 +125,7 @@ Unfreezes supply that was frozen at issuance, once its lock period has elapsed.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-by-id --id 1000001
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-by-id --id 1000001
     ```
 
     - `--id` (required).
@@ -141,7 +141,7 @@ Unfreezes supply that was frozen at issuance, once its lock period has elapsed.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-by-name --name MyToken
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-by-name --name MyToken
     ```
 
     - `--name` (required).
@@ -159,7 +159,7 @@ Token names are not unique; this returns every token sharing a name.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-list-by-name --name MyToken
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-list-by-name --name MyToken
     ```
 
     - `--name` (required).
@@ -175,7 +175,7 @@ Token names are not unique; this returns every token sharing a name.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-asset-issue
+    java -jar java/build/libs/wallet-cli.jar --network nile list-asset-issue
     ```
 
 === "REPL"
@@ -189,7 +189,7 @@ Token names are not unique; this returns every token sharing a name.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-asset-issue-paginated \
+    java -jar java/build/libs/wallet-cli.jar --network nile list-asset-issue-paginated \
       --offset 0 --limit 20
     ```
 

--- a/docs/clients/wallet-cli/typescript-cli-signing.md
+++ b/docs/clients/wallet-cli/typescript-cli-signing.md
@@ -1,0 +1,137 @@
+# TypeScript CLI signing and security
+
+The TypeScript CLI supports software keystores, Ledger accounts, and watch-only accounts. Software
+private keys stay encrypted locally, Ledger private keys never leave the device, and watch-only
+accounts can query state but cannot sign.
+
+## Sign an existing transaction
+
+`tx sign` signs a TRON transaction constructed outside wallet-cli without broadcasting it:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json
+```
+
+For a software account, signing is offline and `--network` is optional. The command is a pure
+signer: it does not decide whether the signer owns the transaction, whether a contract call is
+desirable, or how much value should move. The caller remains responsible for policy checks.
+
+### Transaction integrity
+
+A TRON transaction represents its content in three related fields:
+
+| Field | Purpose |
+|-------|---------|
+| `raw_data` | Human- and application-readable transaction content. |
+| `raw_data_hex` | Bytes executed by the node. |
+| `txID` | Hash covered by the signature. |
+
+Before signing, wallet-cli requires `txID` to equal the SHA-256 hash of `raw_data_hex`. It also
+decodes the outer transaction envelope and requires the contract types declared in `raw_data` to
+match those encoded in `raw_data_hex`. For contract types that can be re-encoded, it additionally
+requires the field-level contents of `raw_data` to produce the same bytes. A mismatch returns
+`tx_integrity` and no signature is produced.
+
+`MarketSellAssetContract`, `MarketCancelOrderContract`, and `ShieldedTransferContract` cannot be
+re-encoded by the underlying library. Their transaction hash and contract type are still checked,
+but their `raw_data` field values cannot be verified against `raw_data_hex`; callers must treat those
+displayed field values as unverified.
+
+### Multi-signature transactions
+
+When the input already contains a `signature` array, `tx sign` appends the new signature rather than
+replacing existing signatures. The same partially signed transaction can therefore move from one
+authorized signer to the next until its permission threshold is met.
+
+Extract the signed payload and broadcast it later:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json |
+  jq -c '.data.signed' > signed.json
+
+wallet-cli tx broadcast --network tron:nile --tx-stdin < signed.json
+```
+
+Text output prints the complete signature rather than an abbreviated transaction identifier.
+
+## Sign typed data
+
+`typed-data sign` signs EIP-712/TIP-712 structured data and returns the signer address, inferred or
+declared primary type, digest, and signature:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli typed-data sign \
+    --typed-data "$TYPED_DATA_JSON" \
+    --password-stdin \
+    --output json
+```
+
+The payload follows the usual `domain`, `types`, `primaryType`, and `message` structure. The CLI:
+
+- ignores `EIP712Domain` when it appears inside `types`;
+- accepts `value` as an alias for `message`;
+- accepts TRON Base58 addresses in `address` fields;
+- infers `primaryType` when omitted and reports the resolved type;
+- rejects a declared `primaryType` that is not the root message type.
+
+`domain.chainId` is signed exactly as supplied and is not compared with `--network`. Review the
+domain and message before signing.
+
+## Ledger behavior
+
+Both `tx sign` and `typed-data sign` support Ledger accounts. Transaction-integrity checks run
+before software and Ledger signing alike.
+
+Typed-data signing uses the TRON application's hash-signing capability. Enable
+**Settings > Sign by Hash > Allowed** on the device. Otherwise the CLI returns
+`ledger_setting_required`. A TRON application version that does not support the instruction returns
+`ledger_unsupported`.
+
+Other Ledger application settings, such as transaction data or custom-contract signing, are also
+reported as actionable `ledger_setting_required` errors instead of an opaque APDU error. A device
+timeout or cancellation closes the transport so a later attempt can reconnect cleanly.
+
+The Ledger screen cannot render every typed-data field and may show only hashes. Verify the payload
+on the host before approving it on the device.
+
+## Secret input policy
+
+Secrets are never accepted as command-line arguments or environment configuration.
+
+The supported stdin channels are:
+
+| Flag | Input |
+|------|-------|
+| `--password-stdin` | Master password used to unlock a software keystore. |
+| `--tx-stdin` | Signed transaction JSON consumed by `tx broadcast`. |
+| `--message-stdin` | Message consumed by `message sign`. |
+
+Only one `*-stdin` flag can consume stdin in a single invocation.
+
+The following high-value setup operations are interactive-only and require hidden input from a real
+TTY:
+
+- `import mnemonic`
+- `import private-key`
+- `change-password`
+
+They do not accept `--mnemonic-stdin`, `--private-key-stdin`, or `--password-stdin`. Without a TTY,
+they fail with `tty_required`.
+
+## Failure behavior
+
+- Watch-only accounts return `watch_only_no_signer` before a signing or write operation starts.
+- Invalid global values return `invalid_value` rather than falling back to defaults.
+- Ledger setting and version problems use `ledger_setting_required` and `ledger_unsupported`.
+- A transaction whose representations disagree returns `tx_integrity`.
+- User or device refusal returns `signing_rejected`.
+
+JSON mode returns these codes in a single `wallet-cli.result.v1` envelope and uses exit code 1 for
+execution failures and exit code 2 for invalid usage.
+
+For complete field-level command references, see
+[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md) and
+[`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md).

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -89,10 +89,16 @@ wallet-cli change-password
 `import mnemonic`, `import private-key`, and `change-password` are interactive-only. They require a
 real terminal and read secrets through hidden prompts; there is no non-interactive stdin alternative.
 
+For non-interactive use with commands such as `derive`, `backup`, and `tx sign`, provide the master
+password through `--password-stdin`. When signing with a Ledger account, do not pipe a password or
+pass `--password-stdin`. The `derive` example below shows the complete non-interactive form. To keep
+later examples concise, they may omit the password pipe and `--password-stdin`.
+
 For HD sub-account derivation, pass the HD seed id shown by `wallet-cli list`.
 
 ```bash
-wallet-cli derive --seed-id wlt_ab12cd34 --label operations
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli derive --seed-id wlt_ab12cd34 --label operations --password-stdin
 ```
 
 Deleting a root HD wallet cascades to accounts derived from that root and cleans orphan labels. In a
@@ -296,14 +302,3 @@ Canonical command ids do not carry a `tron.` prefix: for example, the id is `tx.
 
 Invalid global values such as `--timeout 0` or an unsupported `--output` value fail with
 `invalid_value` instead of silently falling back to a default.
-
-For non-interactive authentication, pipe only the master password through `--password-stdin`:
-
-```bash
-printf '%s\n' "$WALLET_PASSWORD" | wallet-cli message sign --message 'hello' --password-stdin --output json
-wallet-cli tx broadcast --tx-stdin < signed.json
-```
-
-The password example assumes the shell variable is populated securely and is not exported. Only
-one `*-stdin` flag can consume stdin in each invocation. `import mnemonic`, `import private-key`,
-and `change-password` must be run interactively in a TTY.

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -6,8 +6,7 @@ independent npm version number; `wallet-cli --version` reports the npm package v
 separate from the Java JAR described in the rest of this section: the Java CLI uses commands such
 as `send-coin`, while the TypeScript CLI uses grouped commands such as `tx send`.
 
-The TypeScript CLI currently supports TRON mainnet, Nile, and Shasta. EVM chains are not supported
-by this version.
+The TypeScript CLI currently supports TRON mainnet, Nile, and Shasta. EVM chains are not supported.
 
 ## Install
 
@@ -50,11 +49,17 @@ Common global options include:
 | `--timeout` | Per RPC/device-call timeout in milliseconds. |
 | `--verbose`, `-v` | Show extra diagnostics. |
 | `--wait` | After broadcast, poll until the transaction is confirmed or failed. |
-| `--wait-timeout` | Polling cap for `--wait`, in milliseconds. |
+| `--wait-timeout` | Polling cap for `--wait`, in milliseconds; defaults to `config.waitTimeoutMs` (built-in: 60000). |
 | `--password-stdin` | Read the master password from stdin. |
 
-Command-scoped stdin flags include `--mnemonic-stdin`, `--private-key-stdin`, `--tx-stdin`, and
-`--message-stdin`. Only one `*-stdin` flag can consume stdin in a single invocation.
+Command-scoped stdin flags are `--tx-stdin` and `--message-stdin`. Together with the global
+`--password-stdin`, only one `*-stdin` flag can consume stdin in a single invocation.
+
+Use `wallet-cli config` to persist defaults. For example:
+
+```bash
+wallet-cli config waitTimeoutMs 90000
+```
 
 ## Wallets and accounts
 
@@ -78,9 +83,13 @@ wallet-cli use main
 wallet-cli current
 wallet-cli rename main --label primary
 wallet-cli backup primary --out ~/primary-backup.json
+wallet-cli change-password
 ```
 
-HD sub-account derivation is explicit in 4.9.7: pass the HD seed id shown by `wallet-cli list`.
+`import mnemonic`, `import private-key`, and `change-password` are interactive-only. They require a
+real terminal and read secrets through hidden prompts; there is no non-interactive stdin alternative.
+
+For HD sub-account derivation, pass the HD seed id shown by `wallet-cli list`.
 
 ```bash
 wallet-cli derive --seed-id wlt_ab12cd34 --label operations
@@ -105,13 +114,17 @@ wallet-cli tx send --to T... --contract TR7... --amount 5
 wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000
 ```
 
-State-changing commands support three execution modes:
+Transaction-building commands support three execution modes:
 
 | Mode | Behavior |
 |------|----------|
 | default | Build, sign, and broadcast. |
 | `--dry-run` | Build and estimate without signing or broadcasting. |
 | `--sign-only` | Sign and output the transaction without broadcasting. |
+
+The default mode returns after the transaction is submitted. Add `--wait` to poll the FullNode's
+unconfirmed view until the transaction is confirmed or failed. If the polling cap is reached, the
+CLI returns the submitted receipt rather than pretending that the broadcast failed.
 
 Broadcast a signed transaction later with:
 
@@ -126,10 +139,20 @@ wallet-cli tx status --txid <TXID>
 wallet-cli tx info --txid <TXID> --output json
 ```
 
-## Queries and signing
+The CLI also provides a pure, offline-capable signer for transactions constructed elsewhere:
 
-Wallet-bound account queries use the active account by default, or the account selected with
-`--account`.
+```bash
+wallet-cli tx sign --transaction "$TX_JSON"
+```
+
+It always verifies that `txID` is the hash of `raw_data_hex` and that the declared contract types
+match the encoded transaction. For contract types that can be re-encoded, it also verifies the
+field-level contents of `raw_data`. It appends to an existing signature array for multi-signature
+workflows. See [Signing and security](typescript-cli-signing.md#sign-an-existing-transaction).
+
+## Queries
+
+Wallet-bound queries use the active account by default, or the account selected with `--account`.
 
 ```bash
 wallet-cli account info --output json
@@ -138,8 +161,17 @@ wallet-cli account portfolio
 wallet-cli networks
 wallet-cli block
 wallet-cli block 12345
-wallet-cli message sign --message 'hello'
+wallet-cli chain params
+wallet-cli chain prices
+wallet-cli chain node
+wallet-cli stake info
+wallet-cli stake delegated --direction out
+wallet-cli vote status
+wallet-cli reward balance
 ```
+
+For field-level command semantics and additional examples, see the
+[upstream TypeScript command reference](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands).
 
 ## Tokens and contracts
 
@@ -181,6 +213,9 @@ wallet-cli contract deploy \
 In JSON output, a successful TypeScript CLI contract deployment includes the deployed
 `contractAddress` in the deploy receipt data.
 
+`contract info` returns a not-found error when the address has no deployed contract instead of
+returning an empty contract.
+
 Contract deployment requires a software account. The Ledger TRON app cannot sign
 `CreateSmartContract`, so Ledger-backed accounts cannot use `wallet-cli contract deploy`.
 
@@ -195,10 +230,48 @@ wallet-cli stake undelegate --amount-sun 1000000 --receiver T... --resource ener
 wallet-cli stake unfreeze --amount-sun 1000000 --resource energy --dry-run
 wallet-cli stake cancel-unfreeze --dry-run
 wallet-cli stake withdraw --dry-run
+wallet-cli stake info
+wallet-cli stake delegated --direction out
 ```
 
 `stake cancel-unfreeze` requires a software account; the Ledger TRON app cannot sign
 `CancelAllUnfreezeV2Contract`.
+
+`stake withdraw` checks the withdrawable amount before building a transaction and returns
+`nothing_to_withdraw` when no expired unfreeze is available.
+
+## Voting and rewards
+
+The TypeScript CLI can inspect super representatives, replace the account's vote allocation, query
+claimable rewards, and withdraw those rewards:
+
+```bash
+wallet-cli vote list
+wallet-cli vote status
+wallet-cli vote cast --for TZ4...=600 --for TT5...=400
+wallet-cli reward balance
+wallet-cli reward withdraw
+```
+
+`vote cast` replaces the complete existing vote allocation; omitted SRs receive zero votes. Both
+`vote cast` and `reward withdraw` create transactions and require a signing account.
+`reward withdraw` returns `no_reward` when the claimable balance is empty and
+`withdraw_too_frequent` when the 24-hour withdrawal interval has not elapsed.
+
+## Signing
+
+In addition to `message sign`, the CLI provides `tx sign` and EIP-712/TIP-712 `typed-data sign`.
+Software and Ledger accounts are supported; watch-only accounts fail before a write or signing
+operation begins.
+
+```bash
+wallet-cli message sign --message 'hello'
+wallet-cli tx sign --transaction "$TX_JSON"
+wallet-cli typed-data sign --typed-data "$TYPED_DATA_JSON"
+```
+
+See [Signing and security](typescript-cli-signing.md) for transaction-integrity checks,
+multi-signature behavior, Ledger settings, and secret-input rules.
 
 ## Automation
 
@@ -218,16 +291,19 @@ wallet-cli --json-schema
 wallet-cli tx send --json-schema
 ```
 
-For secret input, pipe secrets through stdin rather than argv or exported environment variables:
+Canonical command ids do not carry a `tron.` prefix: for example, the id is `tx.send`, not
+`tron.tx.send`. The network family remains available separately in `chain.family`.
+
+Invalid global values such as `--timeout 0` or an unsupported `--output` value fail with
+`invalid_value` instead of silently falling back to a default.
+
+For non-interactive authentication, pipe only the master password through `--password-stdin`:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" | wallet-cli message sign --message 'hello' --password-stdin --output json
-printf '%s\n' "$MNEMONIC" | wallet-cli import mnemonic --label main --mnemonic-stdin
-printf '%s\n' "$PRIVATE_KEY" | wallet-cli import private-key --label hot --private-key-stdin
+wallet-cli tx broadcast --tx-stdin < signed.json
 ```
 
-These examples assume the shell variables are populated securely and are not exported. Only one
-`*-stdin` flag can consume stdin in each invocation. Commands such as `import mnemonic` and
-`import private-key` need both the master password and the mnemonic/private key; if you pipe one
-secret, the other must be entered interactively in a TTY. They cannot be completed as a fully
-non-interactive single-stdin invocation.
+The password example assumes the shell variable is populated securely and is not exported. Only
+one `*-stdin` flag can consume stdin in each invocation. `import mnemonic`, `import private-key`,
+and `change-password` must be run interactively in a TTY.

--- a/docs/clients/wallet-cli/wallet-management.md
+++ b/docs/clients/wallet-cli/wallet-management.md
@@ -22,7 +22,7 @@ Creates a brand-new wallet with a freshly generated mnemonic and stores an encry
 
     ```bash
     export MASTER_PASSWORD='your-wallet-password'
-    java -jar build/libs/wallet-cli.jar --network nile register-wallet --name my-wallet --words 12
+    java -jar java/build/libs/wallet-cli.jar --network nile register-wallet --name my-wallet --words 12
     ```
 
     - `--name` (required) — wallet name.
@@ -45,7 +45,7 @@ Derives an additional account from the current wallet's mnemonic at a given inde
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile generate-sub-account --index 1 --name sub-1
+    java -jar java/build/libs/wallet-cli.jar --network nile generate-sub-account --index 1 --name sub-1
     ```
 
     - `--index` (required) — derivation index.
@@ -95,14 +95,14 @@ GenerateAddress [isECKey]
 
     ```bash
     # List wallets and their active status
-    java -jar build/libs/wallet-cli.jar list-wallet
+    java -jar java/build/libs/wallet-cli.jar list-wallet
 
     # Set the active wallet by address or by name
-    java -jar build/libs/wallet-cli.jar set-active-wallet --address TXyz...
-    java -jar build/libs/wallet-cli.jar set-active-wallet --name my-wallet
+    java -jar java/build/libs/wallet-cli.jar set-active-wallet --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar set-active-wallet --name my-wallet
 
     # Show the current active wallet
-    java -jar build/libs/wallet-cli.jar get-active-wallet
+    java -jar java/build/libs/wallet-cli.jar get-active-wallet
     ```
 
     - `set-active-wallet` accepts `--address` or `--name` (provide one).
@@ -153,7 +153,7 @@ Prompts for the current password and a new password.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar modify-wallet-name --name new-name
+    java -jar java/build/libs/wallet-cli.jar modify-wallet-name --name new-name
     ```
 
     - `--name` (required) — the new wallet name. Requires auth.
@@ -171,7 +171,7 @@ Deletes the encrypted keystore file(s) for the wallet from local storage. This i
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar clear-wallet-keystore --force
+    java -jar java/build/libs/wallet-cli.jar clear-wallet-keystore --force
     ```
 
     - `--force` is syntactically optional, but required to execute the destructive action in
@@ -190,7 +190,7 @@ Wipes local wallet state back to an initial condition. This is destructive.
 === "Standard CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar reset-wallet --confirm delete-all-wallets
+    java -jar java/build/libs/wallet-cli.jar reset-wallet --confirm delete-all-wallets
     ```
 
     - `--confirm` must be passed with the exact value `delete-all-wallets` to perform the reset.
@@ -239,21 +239,21 @@ mode.
 
 ```bash
 # Add an account alias
-java -jar build/libs/wallet-cli.jar --network nile alias-add \
+java -jar java/build/libs/wallet-cli.jar --network nile alias-add \
   --name treasury --type ACCOUNT --address TXyz... --note "team treasury"
 
 # Add a token alias (with decimals)
-java -jar build/libs/wallet-cli.jar --network nile alias-add \
+java -jar java/build/libs/wallet-cli.jar --network nile alias-add \
   --name usdt --type TOKEN --address TR7NHq... --decimals 6
 
 # List aliases (optionally filter by type)
-java -jar build/libs/wallet-cli.jar --network nile alias-list --type ACCOUNT
+java -jar java/build/libs/wallet-cli.jar --network nile alias-list --type ACCOUNT
 
 # Resolve an alias or address to its canonical form
-java -jar build/libs/wallet-cli.jar --network nile alias-resolve --name treasury
+java -jar java/build/libs/wallet-cli.jar --network nile alias-resolve --name treasury
 
 # Remove a user alias
-java -jar build/libs/wallet-cli.jar --network nile alias-remove --name treasury
+java -jar java/build/libs/wallet-cli.jar --network nile alias-remove --name treasury
 ```
 
 Option notes:

--- a/docs/mechanism-algorithm/multi-signatures.md
+++ b/docs/mechanism-algorithm/multi-signatures.md
@@ -231,7 +231,7 @@ System.out.println(ByteArray.toHexString(operations));
 6. The last user signs and broadcasts.
 7. The node verifies if the total signature weight ≥ `threshold`; if yes, accepts the transaction.
 
->Example code reference: [wallet-cli Example](https://github.com/tronprotocol/wallet-cli/blob/develop/src/main/java/org/tron/common/utils/TransactionUtils.java)
+>Example code reference: [wallet-cli Example](https://github.com/tronprotocol/wallet-cli/blob/develop/java/src/main/java/org/tron/common/utils/TransactionUtils.java)
 
 ## Auxiliary Interfaces
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,17 +276,21 @@ nav:
         - Tools: contracts/tools.md
     - Clients:
         - wallet-cli:
-            - clients/wallet-cli/index.md
-            - Wallet Management: clients/wallet-cli/wallet-management.md
-            - Accounts: clients/wallet-cli/accounts.md
-            - Staking & Resources: clients/wallet-cli/staking.md
-            - Transactions: clients/wallet-cli/transactions.md
-            - Smart Contracts: clients/wallet-cli/smart-contracts.md
-            - TRC-10 Assets: clients/wallet-cli/trc10.md
-            - Governance: clients/wallet-cli/governance.md
-            - GasFree: clients/wallet-cli/gasfree.md
-            - Queries: clients/wallet-cli/query.md
-            - TypeScript / npm CLI: clients/wallet-cli/typescript-cli.md
+            - Overview: clients/wallet-cli/index.md
+            - Java CLI:
+                - Overview: clients/wallet-cli/java-cli.md
+                - Wallet Management: clients/wallet-cli/wallet-management.md
+                - Accounts: clients/wallet-cli/accounts.md
+                - Staking & Resources: clients/wallet-cli/staking.md
+                - Transactions: clients/wallet-cli/transactions.md
+                - Smart Contracts: clients/wallet-cli/smart-contracts.md
+                - TRC-10 Assets: clients/wallet-cli/trc10.md
+                - Governance: clients/wallet-cli/governance.md
+                - GasFree: clients/wallet-cli/gasfree.md
+                - Queries: clients/wallet-cli/query.md
+            - TypeScript / npm CLI:
+                - Overview: clients/wallet-cli/typescript-cli.md
+                - Signing & Security: clients/wallet-cli/typescript-cli-signing.md
     - Releases:
         - Deployment Manual for the New Version: releases/upgrade-instruction.md
         - Integrity Check: releases/signature_verification.md


### PR DESCRIPTION
## Summary

- Reorganize the wallet-cli navigation around a shared overview and separate Java and TypeScript / npm CLI sections.
- Add a dedicated Java CLI overview and update Java build, JAR, resource, and source paths for the `java/` layout.
- Document the current TypeScript CLI signing, security, confirmation, staking, voting, and reward behavior.

## Why

wallet-cli v4.10.0 reorganizes the Java project under `java/` and expands the TypeScript CLI command and signing surface. The documentation needs to reflect the current repository layout and clearly distinguish the two implementations.

## Impact

Readers can choose the appropriate implementation from the wallet-cli overview, follow valid Java commands and paths, and use the latest TypeScript CLI workflows and security behavior.

## Validation

- `mkdocs build --strict`
- `git diff --check`
