### PR TITLE
align tvm documentation with java-tron v4.8.2

### DIFF
--- a/docs/api/http/smart-contract/estimateenergy.md
+++ b/docs/api/http/smart-contract/estimateenergy.md
@@ -59,6 +59,9 @@ Response example:
 
 When `vm.estimateEnergy=true` is not enabled, the call goes through the `ContractValidateException` branch (see below): `result.code = CONTRACT_VALIDATE_ERROR` and `result.message` is `this node does not support estimate energy`.
 
+Energy estimation executes through the constant-call path and is subject to
+[`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration).
+
 ### Error responses
 
 This endpoint never writes `{"Error": ...}` after the request reaches the servlet. Servlet-handled exceptions are caught and written into `result.code` / `result.message`; the HTTP body is still an `EstimateEnergyMessage`.

--- a/docs/api/http/smart-contract/triggerconstantcontract.md
+++ b/docs/api/http/smart-contract/triggerconstantcontract.md
@@ -95,6 +95,12 @@ Response example (real Nile capture):
 
 > `txID` / `ref_block_*` / `expiration` / `timestamp` / `raw_data_hex` and other ephemeral fields share semantics with [`/wallet/createtransaction`](../tx-build-and-broadcast/createtransaction.md). Constant calls do not go on-chain; the `transaction` field is provided only as context.
 
+> **Execution timeout:** This endpoint uses the node's constant-call execution
+> deadline. `vm.constantCallTimeoutMs = 0` uses the network's
+> `MAX_CPU_TIME_OF_ONE_TX` limit; a positive value sets a constant-call-only
+> deadline in milliseconds. See
+> [TVM and constant-call configuration](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration).
+
 ### Error responses
 
 This endpoint never writes `{"Error": ...}` after the request reaches the servlet. Servlet-handled exceptions are caught and written into `result.code` / `result.message`; the HTTP body is still a `TransactionExtention`. Note: **EVM revert / runtime errors do not go through `result.code`** — instead `result.result=true`, `message` carries the revert/runtime info, and the failure is marked at `transaction.ret[0].ret="FAILED"`.

--- a/docs/api/http/smart-contract/triggersmartcontract.md
+++ b/docs/api/http/smart-contract/triggersmartcontract.md
@@ -92,6 +92,10 @@ Response example (real Nile capture):
 
 > For simulation only (no on-chain effect), use [`/wallet/triggerconstantcontract`](triggerconstantcontract.md); for energy estimation only, use [`/wallet/estimateenergy`](estimateenergy.md).
 
+> When the ABI marks the target function as `view` or `pure`, this endpoint is
+> dispatched through the constant-call path and is therefore subject to
+> [`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration).
+
 ### Error responses
 
 This endpoint never writes `{"Error": ...}` after the request reaches the servlet. Servlet-handled exceptions are caught and written into `result.code` / `result.message`; the HTTP body is still a `TransactionExtention`.

--- a/docs/api/json-rpc/smart-contract/eth_call.md
+++ b/docs/api/json-rpc/smart-contract/eth_call.md
@@ -54,6 +54,11 @@ The example below is the real response captured from the Nile testnet curl above
 }
 ```
 
+`eth_call` executes through the node's constant-call path and is subject to
+[`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration).
+The default value `0` uses the network's `MAX_CPU_TIME_OF_ONE_TX` limit; a
+positive value sets a constant-call-only deadline in milliseconds.
+
 ### Error responses
 
 | Trigger | Code | message |

--- a/docs/api/json-rpc/smart-contract/eth_estimateGas.md
+++ b/docs/api/json-rpc/smart-contract/eth_estimateGas.md
@@ -38,8 +38,12 @@ Hex-encoded energy usage:
 
 - Plain TRX transfer (`TransferContract`) → `0x0`
 - Contract call / deployment → depends on node config:
-    - `node.supportEstimateEnergy = true` returns `EstimateEnergyMessage.energyRequired`
+    - `vm.estimateEnergy = true` returns `EstimateEnergyMessage.energyRequired`
     - Default (false) → returns `TransactionExtention.energyUsed` (the actual usage of one constant-call)
+
+Contract-call and deployment estimation use the constant-call path and are
+subject to
+[`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration).
 
 The example below is the real response captured from the Nile testnet curl above (the TRX transfer takes the `TransferContract` path and returns `0x0` directly without entering the EVM):
 

--- a/docs/contracts/contract.md
+++ b/docs/contracts/contract.md
@@ -102,6 +102,9 @@ There is a special type of message call, delegate call. The difference with comm
 This command will create a new contract with a new address. The primary difference from Ethereum is that the new TRON address is derived as `sha3omit12(rootTransactionId || nonce)` — the root transaction id concatenated with the 8-byte nonce, then hashed (the nonce itself is **not** pre-hashed); the final 21-byte address has a leading `0x41` TRON address prefix. Different from Ethereum (where nonce is the sender account's transaction nonce), here `nonce` is a per-root-transaction counter that increments on every internal action (internal call, transfer, `CREATE`, suicide, etc.), not only on `CREATE`. Refer to `TransactionUtil.generateContractAddress(byte[], long)` for the exact implementation.
 **Note**: Different from creating a contract by grpc's `deployContract`, contract created by `CREATE` command does not store contract abi.
 
+When `ALLOW_TVM_OSAKA` is active, `CREATE2` at the maximum call depth pushes
+zero instead of attempting another contract creation.
+
 #### built-in function and built-in function attribute
 
 1. TVM is compatible with solidity language's transfer format, including:
@@ -121,7 +124,13 @@ This command will create a new contract with a new address. The primary differen
    inside a contract. Enabled by the `ALLOW_TVM_VOTE` chain parameter,
    activated on mainnet by committee [proposal #84](https://tronscan.io/#/proposal/84).
    Provides `VOTEWITNESS` / `WITHDRAWREWARD` opcodes and related read-only
-   precompiles.
+   precompiles. At execution time, TVM selects the `VOTEWITNESS` Energy
+   calculation from the active chain parameters. When `ALLOW_TVM_OSAKA` is
+   active, it uses `BigInteger` for dynamic-array offsets, lengths, and memory
+   bounds to prevent 256-bit wraparound. Otherwise, it uses the
+   energy-adjustment calculation when `ALLOW_ENERGY_ADJUSTMENT` is active, or
+   the original calculation without the energy-adjustment and Osaka
+   overflow-protection changes when neither parameter is active.
 
 3. TRC-10 token operations: sending TRC-10 to a target address and querying
    the TRC-10 balance of an address. Enabled by the `ALLOW_TVM_TRANSFER_TRC10`
@@ -209,6 +218,24 @@ We recommend to use tron-studio instead of remix to build TRON smart contract.
 #### Block Related
 
 - `blockhash(uint blockNumber) returns (bytes32)`: specified block hash, can only apply to the latest 256 blocks and current block excluded. **Note**: the form `block.blockhash(uint)` was deprecated in upstream Solidity 0.4.22 and removed in 0.5.0; TRON's Solidity fork inherits the deprecation from `tv_0.4.24` and the removal from `tv_0.5.4` onwards — use the top-level `blockhash(...)` instead
+
+    For access to older block hashes, the `ALLOW_TVM_PRAGUE` chain parameter
+    (ID 95) deploys the
+    [TIP-2935](https://github.com/tronprotocol/tips/blob/master/tip-2935.md)
+    block-hash history contract at
+    `0x0000F90827F1C53a10cb7A02335B175320002935`. This parameter requires
+    `ALLOW_TVM_SHANGHAI` to be active first because the history contract
+    bytecode uses `PUSH0`.
+
+    The contract stores parent block hashes in an 8191-slot ring buffer. For a
+    32-byte encoded block number `K`, the query is valid when `K` is in
+    `[block.number - 8191, block.number - 1]`; a future block or a block outside
+    that window causes the call to revert. Activation does not backfill hashes
+    from earlier blocks, so the buffer fills progressively after the parameter
+    takes effect.
+
+    This contract supplements rather than changes the `BLOCKHASH` opcode.
+
 - `block.basefee` (uint): returns the network energy fee from chain parameter (`getEnergyFee`); unlike Ethereum's per-block EIP-1559 base fee, this value only changes when a committee proposal modifies it. Available since the London upgrade (`ALLOW_TVM_LONDON`), activated on mainnet by committee [proposal #72](https://tronscan.io/#/proposal/72)
 - `block.coinbase` (address): Super Representative address that produced the current block
 - `block.difficulty` (uint): current block difficulty, not recommended, set 0

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -152,6 +152,40 @@ Use `node.disabledApi` to disable selected HTTP, gRPC, or PBFT methods. It does 
 
 Do not expose administrative or transaction-building APIs directly to an untrusted network. Restrict listening access with host or network controls, and place public services behind an appropriately configured gateway when necessary. See the [HTTP API](../api/http/index.md) and [JSON-RPC API](../api/json-rpc/index.md) guides for protocol-specific behavior.
 
+## TVM and constant-call configuration
+
+TVM simulation and Energy-estimation behavior is configured under `vm`:
+
+| Configuration path | Default | Purpose |
+|---|---:|---|
+| `vm.supportConstant` | `false` | Enables read-only constant-contract execution. |
+| `vm.maxEnergyLimitForConstant` | `100000000` | Maximum Energy available to one constant call. Values below 3,000,000 are raised to that minimum during configuration binding. |
+| `vm.estimateEnergy` | `false` | Enables the dedicated `estimateenergy` implementation. |
+| `vm.estimateEnergyMaxRetry` | `3` | Maximum retries while estimating Energy; values are constrained to the range 0–10. |
+| `vm.constantCallTimeoutMs` | `0` | Optional execution deadline, in milliseconds, for calls routed through the constant-call path. |
+| `vm.vmTrace` | `false` | Enables TVM trace output. |
+
+`vm.constantCallTimeoutMs = 0` preserves the original behavior, in which a
+constant call uses the network's `MAX_CPU_TIME_OF_ONE_TX` limit. A positive
+value sets a constant-call-only deadline in milliseconds. Negative values, or
+values too large to convert safely to the VM's microsecond deadline, cause
+configuration loading to fail. The deadline is not enforced in debug mode or
+by a standalone SolidityNode. Constant calls sent to a FullNode's
+`/walletsolidity` endpoints are still subject to the deadline.
+
+The setting applies to constant-call execution across HTTP, gRPC, and
+JSON-RPC, including
+[`/wallet/triggerconstantcontract`](../api/http/smart-contract/triggerconstantcontract.md),
+[`/wallet/triggersmartcontract`](../api/http/smart-contract/triggersmartcontract.md)
+when an ABI `view`/`pure` function is dispatched to the constant-call path,
+[`/wallet/estimateenergy`](../api/http/smart-contract/estimateenergy.md),
+[`eth_call`](../api/json-rpc/smart-contract/eth_call.md), and
+[`eth_estimateGas`](../api/json-rpc/smart-contract/eth_estimateGas.md).
+
+For production nodes, use `vm.constantCallTimeoutMs` when complex read-only
+calls need more time. Changes to these `vm` settings require a process restart;
+they are not part of dynamic configuration reload.
+
 ## Rate limiting
 
 API limits are configured under `rate.limiter`:

--- a/docs/using_javatron/private_network.md
+++ b/docs/using_javatron/private_network.md
@@ -128,10 +128,10 @@ The operational steps for deploying a private network node are fundamentally the
 
      - **Method 2: Modify via On-Chain Proposals (For a Running Network)**
 
-        This is the standard method for on-chain governance. Any Super Representative (SR), SR Partner, or SR Candidate has the right to create a proposal, but only SRs have the right to vote on its approval.
+        This is the standard method for on-chain governance. Any Super Representative (SR), SR Partner, or SR Candidate can create or approve a proposal, but only approvals from active SRs count toward the approval threshold.
      
          - Create a Proposal: Any SR, SR Partner, or SR Candidate uses the [proposalcreate](../api/http/witness-and-governance/proposalcreate.md) API, specifying the parameter to be modified by its ID and the new value. (List of parameter IDs).
-         - Approve a Proposal: An SR uses the [proposalapprove](../api/http/witness-and-governance/proposalapprove.md) API to vote on the proposal. (Only 'approve' votes are supported; if an SR does not vote, it is considered a 'disapprove').
+         - Approve a Proposal: An SR uses the [proposalapprove](../api/http/witness-and-governance/proposalapprove.md) API to approve a proposal or withdraw an approval. When determining whether the proposal meets the approval threshold, only approvals from active SRs are counted; an SR that has not approved or has withdrawn approval does not increase the approval count.
          - Related APIs:
              - Get all proposals: [listproposals](../api/http/witness-and-governance/listproposals.md)
              - Get a proposal by ID: [getproposalbyid](../api/http/witness-and-governance/getproposalbyid.md)
@@ -174,4 +174,4 @@ The operational steps for deploying a private network node are fundamentally the
 
          Once the proposal is approved and the maintenance period has passed, the new network parameters will take effect. You can verify the changes using [listproposals](../api/http/witness-and-governance/listproposals.md) or [getchainparameters](../api/http/witness-and-governance/getchainparameters.md).
     
-         It is important to note that network parameters with interdependencies cannot be included in the same proposal. The correct approach is to separate them into different proposals and pay attention to their order of submission.
+         It is important to note that network parameters with interdependencies cannot be included in the same proposal. The correct approach is to separate them into different proposals and pay attention to their order of submission. For example, activate `ALLOW_TVM_SHANGHAI` before creating a proposal to enable parameter 95 (`ALLOW_TVM_PRAGUE`).


### PR DESCRIPTION
## Summary

- Align TVM contract documentation with java-tron v4.8.2 behavior, including CREATE2 depth handling and VOTEWITNESS Energy calculation selection.
- Document TIP-2935 block-hash history, the Prague/Shanghai activation dependency, and governance approval semantics.
- Document constant-call timeout configuration and the supported HTTP, gRPC, and JSON-RPC paths.
- Clarify the `MAX_CPU_TIME_OF_ONE_TX` deadline and correct the `eth_estimateGas` configuration key.

## Why

The documentation had drifted from current java-tron TVM and API behavior. These changes bring the documented behavior and configuration back in line with the source implementation.

## Validation

- Reviewed the changes against the java-tron source.
- Ran `mkdocs build --strict` successfully.
