### PR TITLE
align moniter documentation with java-tron v4.8.2

### DIFF
--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -177,7 +177,22 @@ Restrict the configuration and keystore files to the node's operating-system use
 
 Event delivery is controlled by `event.subscribe`. Its settings select the native queue or event plugin, the plugin path or target server, and the enabled trigger topics. See [Event Subscription](../architecture/event.md) for a complete setup.
 
-Prometheus monitoring is configured under `node.metrics.prometheus`, including its enable switch and listening port. See [Node Monitoring](metrics.md) for collection and dashboard instructions.
+Prometheus monitoring is configured under `node.metrics.prometheus`. It is disabled by default and listens on port `9527` when enabled:
+
+```hocon
+node.metrics {
+  prometheus {
+    enable = true
+    port = 9527
+  }
+}
+```
+
+The deprecated `node.metricsEnable` setting is separate from the Prometheus switch. It enables legacy Dropwizard metrics collection and registers the gRPC `Monitor` service (`GetStatsInfo`).
+
+Starting with GreatVoyage-v4.8.2, the InfluxDB reporter is no longer supported. `node.metrics.storageEnable` and the entire `node.metrics.influxdb` block are no longer used and can be removed from your configuration.
+
+See [Node Monitoring](metrics.md) for metric descriptions, collection, PromQL examples, and dashboard instructions.
 
 ## Dynamic configuration reload
 

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -177,7 +177,7 @@ Restrict the configuration and keystore files to the node's operating-system use
 
 Event delivery is controlled by `event.subscribe`. Its settings select the native queue or event plugin, the plugin path or target server, and the enabled trigger topics. See [Event Subscription](../architecture/event.md) for a complete setup.
 
-Prometheus monitoring is configured under `node.metrics.prometheus`. It is disabled by default and listens on port `9527` when enabled:
+Prometheus monitoring is configured under `node.metrics.prometheus`. It is disabled by default. When enabled, it listens on port `9527` by default; the listening port can be changed through `node.metrics.prometheus.port`:
 
 ```hocon
 node.metrics {

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -15,6 +15,10 @@ node.metrics = {
 }
 ```
 
+Prometheus monitoring is disabled by default and listens on port `9527` when enabled.
+
+For details about Prometheus and legacy monitoring settings, see [Event subscription and monitoring](configuration.md#event-subscription-and-monitoring).
+
 ## Start the java-tron Node
 
 After updating the configuration, start the node as described in [Starting a java-tron Full Node](installing_javatron.md#starting-a-java-tron-node).
@@ -129,6 +133,3 @@ The deployment process of the Grafana visualization tool is as follows:
     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/metrics_import.png)
     
     Grafana will then render the dashboard according to the imported JSON file, allowing you to monitor the running status of the node in real time.
-
-
-

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -15,7 +15,7 @@ node.metrics = {
 }
 ```
 
-Prometheus monitoring is disabled by default and listens on port `9527` when enabled.
+Prometheus monitoring is disabled by default. When enabled, it listens on port `9527` by default; the listening port can be changed through `node.metrics.prometheus.port`.
 
 For details about Prometheus and legacy monitoring settings, see [Event subscription and monitoring](configuration.md#event-subscription-and-monitoring).
 


### PR DESCRIPTION
## Summary

- clarify the Prometheus switch, default listener settings, and the deprecated legacy monitoring setting
- document that the removed InfluxDB settings are no longer used and can be cleaned up
- keep the metrics deployment guide focused by linking to the precise configuration section

## Why

The monitoring guidance did not clearly distinguish the embedded Prometheus HTTP endpoint from legacy Dropwizard metrics and the gRPC `Monitor` service. It also implied that obsolete InfluxDB settings had to be removed before upgrading, although current java-tron ignores them.

## Impact

Node operators get clearer configuration guidance without duplicating monitoring details across the configuration and deployment guides. This is a documentation-only change.

## Validation

- audited the documented switches and service registration against the local java-tron source
- ran `mkdocs build --strict`
- ran `git diff --check`
