### PR TITLE
Add all official Lite FullNode snapshot sources

### DIFF
--- a/docs/using_javatron/backup_restore.md
+++ b/docs/using_javatron/backup_restore.md
@@ -87,7 +87,10 @@ The TRON network has supported **Lite FullNode** type nodes since the GreatVoyag
 
 | Lite FullNode Node Data Source | Download Address | Description |
 | :----------------------------- | :--------------- | :---------- |
-| Official Data Source (Asia: Singapore) | [http://34.143.247.77/](http://34.143.247.77/) | LevelDB data |
+| Official Data Source (Americas: Virginia, USA) | [http://34.86.86.229/](http://34.86.86.229/) | LevelDB data, does not include internal transactions |
+| Official Data Source (Asia: Singapore) | [http://34.143.247.77/](http://34.143.247.77/) | LevelDB data, does not include internal transactions |
+| Official Data Source (Americas: USA) | [http://35.197.17.205/](http://35.197.17.205/) | RocksDB data, does not include internal transactions |
+| Official Data Source (Asia: Singapore) | [http://35.247.128.170/](http://35.247.128.170/) | LevelDB data, includes internal transactions |
 
 **Tip:** If you already have full data from a FullNode, you can use the [Lite FullNode Data Trimming Tool](toolkit.md/#lite-fullnode-data-pruning) to trim your FullNode data into Lite FullNode data yourself.
 


### PR DESCRIPTION
## Summary

The Lite FullNode snapshot table only listed a single Singapore source, while three other official snapshot endpoints also serve Lite FullNode data. This adds those three sources to the Lite FullNode table and annotates every row with its database type and whether internal transactions are included, matching the format already used in the FullNode snapshot table above.

## Test plan

- [x] Verified the four endpoints listed in the Lite FullNode table match the official snapshot sources that publish Lite FullNode data
- [x] Confirmed the database type / internal transaction annotations are consistent with the FullNode snapshot table in the same document
- [x] Markdown table renders correctly