### PR TITLE
add separate CI workflow documentation based on v4.8.2

### DIFF
--- a/docs/developers/demo.md
+++ b/docs/developers/demo.md
@@ -302,6 +302,33 @@ After fixing the code style issues, run the check again to ensure all warnings h
 
 ![CheckStyle 代码风格修复后示例](https://raw.githubusercontent.com/tronprotocol/documentation-en/master/images/demo_codestyle.png)
 
+For faster feedback, you can run the same Checkstyle tasks used by CI from the repository root:
+
+```bash
+./gradlew \
+  :framework:checkstyleMain \
+  :framework:checkstyleTest \
+  :plugins:checkstyleMain
+```
+
+The regular build also runs Checkstyle as part of its broader verification tasks. Before opening a PR, run the full build:
+
+```bash
+./gradlew clean build --no-daemon
+```
+
+On x86-64, the project requires JDK 8 and the regular test task uses LevelDB by default. Run the focused RocksDB engine tests separately:
+
+```bash
+./gradlew :framework:testWithRocksDb --no-daemon
+```
+
+On ARM64, the project requires JDK 17 and the regular framework test task already uses RocksDB. Therefore, `./gradlew clean build --no-daemon` already exercises the framework tests with RocksDB, and the additional `testWithRocksDb` command is normally unnecessary.
+
+GitHub Actions performs additional checks that may not be practical to reproduce completely on one development machine. See [java-tron CI Workflows](workflows.md) for the complete trigger matrix, coverage thresholds, and branch-specific behavior.
+
+Make sure all required checks pass on the PR before requesting final review.
+
 ## 5. Submitting Code and Creating a Pull Request
 
 ### 5.1 Submit a Commit

--- a/docs/developers/java-tron.md
+++ b/docs/developers/java-tron.md
@@ -151,7 +151,7 @@ Once all checks pass, maintainers will review the PR and merge it into the appro
 > **Coding Standards**
 >
 >- Follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
->- All PRs must be based on the `develop` branch
+>- Choose the target branch based on the type of change: regular PRs should target `develop`; fixes for a `release_*` branch should target the corresponding `release_*` branch; post-release emergency fixes should target the corresponding `hotfix/*` branch.
 
 ## Branch Naming Conventions
 

--- a/docs/developers/java-tron.md
+++ b/docs/developers/java-tron.md
@@ -140,12 +140,13 @@ All PRs must be reviewed before merging.
 - Self-test before submission.
 - Pass standardized tests.
 
-CI Tools:
+### Automated CI Checks
 
-- Sonar: Static code analysis
-- Travis CI: Continuous integration checks
+java-tron uses GitHub Actions for PR validation, code and configuration checks, multi-platform builds, coverage gates, integration and security tests, reviewer assignment, and cancellation of work for closed, unmerged PRs. Which workflows run depends on the changed files, event, and target branch.
 
-Once all checks pass, maintainers will review and merge into `develop`.
+See [java-tron CI Workflows](workflows.md) for the trigger matrix, check details, thresholds, and branch-specific behavior.
+
+Once all checks pass, maintainers will review the PR and merge it into the appropriate target branch.
 
 > **Coding Standards**
 >
@@ -163,11 +164,14 @@ Once all checks pass, maintainers will review and merge into `develop`.
 
 1. One PR should address a single issue.
 2. Avoid excessively large changes.
-3. Title: Briefly describe the PR’s purpose.
-4. Description: Provide detailed information for reviewers.
-5. Specify areas where feedback is needed.
-6. Do not capitalize the first letter of the title.
-7. Do not end the title with a period.
+3. Format the title as `type: description` or `type(scope): description`.
+4. Keep the title between 10 and 72 characters.
+5. Use one of these types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `perf`, `build`, or `revert`.
+6. Do not start the description portion of the title with an uppercase ASCII letter, and do not end the title with a period.
+7. Provide a PR description of at least 20 characters that explains what changed and why.
+8. Specify areas where feedback is needed.
+
+The scope is optional. Unknown scopes only produce a warning, and reviewer assignment uses a separate scope mapping. See [Scope Validation and Reviewer Assignment](workflows.md#scope-validation-and-reviewer-assignment) for details.
 
 ## Commit Message Specifications
 
@@ -190,14 +194,18 @@ Recommended format:
 - `refactor`: Code refactoring
 - `test`: Test code changes
 - `chore`: Build process or auxiliary tooling changes (no production code change)
+- `ci`: CI/CD configuration changes
+- `perf`: Performance improvements
+- `build`: Build system or dependency changes
+- `revert`: Reverts an earlier change
 
-The `scope` specifies the place of the change, for example: `protocol`, `api`, `test`, `docs`, `build`, `db`, `net`. Use `*` if there isn't a more fitting scope.
+The `scope` specifies the place of the change, for example: `protocol`, `api`, `test`, `vm`, `config`, `db`, `net`. Use `*` if there isn't a more fitting scope.
 
 ### Subject Specifications
 
-1. Limit to 50 characters; do not end with a period.
+1. Keep the subject between 10 and 72 characters; do not end with a period.
 2. Start with a verb and use the first-person present tense (e.g., use `change` instead of `changed` or `changes`).
-3. Start with a lowercase letter.
+3. Do not start the subject with an uppercase letter.
 4. Avoid meaningless commits. It is recommended to use the `git rebase` command.
 
 Example:

--- a/docs/developers/workflows.md
+++ b/docs/developers/workflows.md
@@ -1,0 +1,89 @@
+# java-tron CI Workflows
+
+This page summarizes the GitHub Actions checks that contributors need to understand when preparing a java-tron pull request. The workflow files in java-tron remain the source of truth if the implementation changes.
+
+## When Workflows Run
+
+| Workflow | Pull request target | Documentation-only PR | Other triggers |
+| --- | --- | --- | --- |
+| PR Check (`pr-check.yml`) | `develop`, `release_**` | Runs | Push to `master` or `release_**` |
+| PR Build (`pr-build.yml`) | `master`, `develop`, `release_**` | Skipped | Manual dispatch |
+| Single-node integration (`integration-test-single-node.yml`) | `develop`, `release_**` | Skipped | Push to `master` or `release_**`; manual dispatch |
+| Multi-node integration (`integration-test-multinode.yml`) | `develop`, `release_**` | Skipped | Push to `master` or `release_**`; manual dispatch |
+| CodeQL (`codeql.yml`) | `develop` | Skipped | Push to `develop`, `master`, or `release_**`; weekly schedule |
+| Math usage (`math-check.yml`) | `develop`, `release_**` | Runs | Push to `master` or `release_**`; manual dispatch |
+| Reviewer assignment (`pr-reviewer.yml`) | `develop`, `release_**` | Runs | None |
+| Cancel PR workflows (`pr-cancel.yml`) | Any branch | Runs when an unmerged PR is closed | None |
+
+PR Build, both integration-test workflows, and CodeQL are skipped when a pull request changes only documentation or certain repository-metadata files. If the same pull request includes any other file, the applicable workflows run normally. PR Check, Math usage, reviewer assignment, and cancellation do not have this path exclusion.
+
+## PR Validation and Code Checks
+
+For pull requests targeting `develop` or `release_**`, PR Check enforces these title and description rules:
+
+- Use `type: description` or `type(scope): description`.
+- Keep the title between 10 and 72 characters.
+- Use one of these types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `ci`, `perf`, `build`, or `revert`.
+- Do not start the description portion with an uppercase ASCII letter, and do not end the title with a period.
+- Provide a PR description of at least 20 characters after leading and trailing whitespace is removed.
+- An unknown scope produces a warning rather than a failure.
+
+The workflow also runs Checkstyle and validates `common/src/main/resources/reference.conf`, including its key format, nesting depth, service-port conflicts, and configuration comments. These checks also run for documentation-only pull requests targeting `develop` or `release_**`.
+
+## Multi-platform Build and Coverage
+
+When triggered by a pull request, PR Build executes the full Gradle build across four environments:
+
+| Environment | Architecture | JDK | Platform-specific checks |
+| --- | --- | --- | --- |
+| macOS 26 | ARM64 | 17 | Regular framework tests use RocksDB |
+| Ubuntu 24.04 | ARM64 | 17 | Regular framework tests use RocksDB |
+| Rocky Linux 8 container | x86-64 | 8 | Focused RocksDB engine tests |
+| Debian 11 container | x86-64 | 8 | Focused RocksDB tests and coverage reports |
+
+The coverage gates require:
+
+- More than 60% coverage for changed Java source lines. The gate is skipped when there are no changed Java source lines.
+- No more than a 0.1 percentage-point decrease in overall coverage relative to the base revision.
+
+## Integration, Security, and Math Checks
+
+The documented source version includes both full integration-test workflows:
+
+- The single-node workflow runs the full test set against one node.
+- The multi-node workflow runs the full test set against a three-witness stack.
+
+They run for applicable pull requests targeting `develop` or `release_**`, on pushes to `master` or `release_**`, and when started manually.
+
+CodeQL runs on pull requests targeting `develop` only. It also runs on pushes to `develop`, `master`, and `release_**`, and on a weekly schedule.
+
+The Math usage workflow rejects direct `java.lang.Math` usage and directs contributors to `org.tron.common.math.StrictMathWrapper`. It also runs for documentation-only pull requests targeting `develop` or `release_**`.
+
+## Scope Validation and Reviewer Assignment
+
+PR validation and reviewer assignment use separate scope lists. PR validation recognizes 32 scopes, while reviewer assignment maps 26 scopes:
+
+| Category | Count | Scopes |
+| --- | ---: | --- |
+| Recognized and mapped by both | 24 | `framework`, `chainbase`, `actuator`, `consensus`, `common`, `crypto`, `plugins`, `protocol`, `net`, `db`, `vm`, `tvm`, `api`, `jsonrpc`, `rpc`, `http`, `event`, `config`, `trie`, `metrics`, `test`, `docker`, `lite`, `toolkit` |
+| Recognized only by PR validation | 8 | `block`, `proposal`, `log`, `version`, `freezeV2`, `DynamicEnergy`, `stable-coin`, `reward` |
+| Mapped only by reviewer assignment | 2 | `backup`, `ci` |
+
+An unknown PR scope only produces a validation warning. Reviewer assignment uses a separate scope mapping.
+
+## Cancellation on Close
+
+When a pull request is closed without being merged, java-tron attempts to cancel queued or running instances of:
+
+- PR Build
+- CodeQL
+- Single-node integration tests
+- Multi-node integration tests
+
+## Sonar Configuration
+
+The java-tron repository retains `sonar-project.properties` and the SonarQube Gradle plugin configuration for static analysis. Sonar is not invoked by java-tron's GitHub Actions workflows. An external Sonar or SonarCloud integration, if configured, is outside the workflow files described here.
+
+## Running Checks Locally
+
+The [development example](demo.md#4-checkstyle-code-style-check) provides the recommended Checkstyle, full-build, and RocksDB commands, including the JDK and storage-engine differences between ARM64 and x86-64.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,6 +263,7 @@ nav:
         - Account Permission Management: mechanism-algorithm/multi-signatures.md
     - For java-tron Developers:
         - Developer Guide: developers/java-tron.md
+        - CI Workflows: developers/workflows.md
         - Core Modules: developers/code-structure.md
         - ChainBase Deep Dive: developers/chainbase.md
         - P2P Network Deep Dive: developers/network.md


### PR DESCRIPTION
## Summary

- Add a dedicated java-tron CI workflow reference based on GreatVoyage-v4.8.2.
- Document workflow triggers, build environments, coverage gates, integration checks, scope validation, and cancellation behavior.
- Link the new page from the developer guide, local development example, and site navigation.

## Validation

- mkdocs build --strict
- git diff --check