### PR TITLE
align wallet-cli documentation with v4.11.0

### DIFF
--- a/docs/clients/wallet-cli/index.md
+++ b/docs/clients/wallet-cli/index.md
@@ -7,11 +7,13 @@ transactions.
 
 The repository provides two implementations:
 
-- **[Java CLI](java-cli.md)** — the original, full-featured implementation. It provides an
-  interactive REPL for people and a non-interactive Standard CLI for scripts using the Java JAR.
+- **[Java CLI](java-cli.md)** — the original implementation. It provides an interactive REPL for
+  people and a non-interactive Standard CLI for scripts using the Java JAR. It has the broadest
+  protocol feature coverage, including TRC-10 issuance, the on-chain DEX, and governance proposals.
 - **[TypeScript / npm CLI](typescript-cli.md)** — an agent-first Node.js implementation published as
   `@tron-walletcli/wallet-cli`, with grouped commands, deterministic exit codes, and structured JSON
-  output.
+  output. It includes first-class [multi-signature](typescript-cli-multisig.md) and
+  [GasFree](typescript-cli-gasfree.md) workflows.
 
 ## Compare entry points
 
@@ -41,10 +43,12 @@ TypeScript CLI operates on an account already stored in its local wallet:
 
 ## Choose an implementation
 
-| Implementation | Command style | Best suited for |
-|----------------|---------------|-----------------|
-| [Java CLI](java-cli.md) | Interactive commands such as `GetAccount`, or Standard CLI commands such as `get-account` | The complete TRON wallet feature set, manual operation, and Java JAR integrations |
-| [TypeScript / npm CLI](typescript-cli.md) | Grouped commands such as `account info` and `tx send` | Automation, CI/CD, structured JSON integrations, and AI agents |
+| Implementation | Command style | Feature emphasis | Best suited for |
+|----------------|---------------|------------------|-----------------|
+| [Java CLI](java-cli.md) | Interactive commands such as `GetAccount`, or Standard CLI commands such as `get-account` | Broadest protocol surface, including TRC-10 issuance, DEX, and governance/proposals | Manual operation and Java JAR integrations |
+| [TypeScript / npm CLI](typescript-cli.md) | Grouped commands such as `account info` and `tx send` | Core wallet operations, multi-sig, GasFree, local utilities, and a stable machine interface | Automation, CI/CD, structured JSON integrations, and AI agents |
 
 The two implementations have separate installation and runtime requirements. Continue with the
-[Java CLI overview](java-cli.md) or the [TypeScript / npm CLI overview](typescript-cli.md).
+[Java CLI overview](java-cli.md) or the [TypeScript / npm CLI overview](typescript-cli.md). For the
+TypeScript implementation's security-sensitive workflows, see [Multi-signature](typescript-cli-multisig.md),
+[GasFree](typescript-cli-gasfree.md), and [Signing and Security](typescript-cli-signing.md).

--- a/docs/clients/wallet-cli/java-cli.md
+++ b/docs/clients/wallet-cli/java-cli.md
@@ -68,9 +68,7 @@ java -jar java/build/libs/wallet-cli.jar help --command send-coin
 
 ## Global options (Standard CLI)
 
-Execution-modifier global options are parsed by `GlobalOptions` and may appear either **before or
-after** the command name. Top-level mode selectors have stricter placement rules, as described
-below.
+The following options configure Standard CLI commands:
 
 | Option | Values | Description |
 |--------|--------|-------------|
@@ -87,26 +85,18 @@ below.
 
 Notes:
 
-- The execution modifiers `--network`, `--grpc-endpoint`, `--output`, `--wallet`, `--quiet`,
-  `--verbose`, and `--password-stdin` are recognized before or after the command name.
-- The top-level mode selectors `--version` and `--interactive` must appear before the command name.
-  After a command, they are treated as command-local arguments instead.
-- `--help` and `-h` before the command request global help; after the command they request help for
-  that command.
-- Valued global options (`--output`, `--network`, `--wallet`, and `--grpc-endpoint`) accept their
-  value either as the next token (`--network nile`) or inline (`--network=nile`).
-- Options that take a value cannot be repeated, and unknown global options are rejected.
+- Network, output, wallet, logging, and password options may appear before or after the command.
+- Put `--version` and `--interactive` before the command name.
+- Put `--help` before a command for global help or after it for command-specific help.
+- Options with values accept both `--network nile` and `--network=nile` forms.
 
 ## Authentication (Standard CLI)
 
 Standard CLI mode is non-interactive, so it never prompts for a password. Commands that build and
-sign a transaction (marked **requires auth** in this documentation) authenticate automatically:
-
-1. The wallet password is read from the `MASTER_PASSWORD` environment variable, or from **stdin**
-   when `--password-stdin` is passed (stdin takes precedence).
-2. The keystore is loaded from the `Wallet/` directory. Use `--wallet <name|path>` to pick a
-   specific wallet, or set an **active wallet** with `set-active-wallet` (see
-   [Wallet Management](wallet-management.md)).
+sign a transaction (marked **requires auth** in this documentation) read the wallet password from
+`MASTER_PASSWORD`, or from stdin when `--password-stdin` is passed. Stdin takes precedence. Use
+`--wallet <name|path>` to select a wallet, or set an **active wallet** with `set-active-wallet` (see
+[Wallet Management](wallet-management.md)).
 
 Most read-only query commands do not require authentication. The exceptions are queries that act on
 the current wallet: `get-address` always requires auth, and `get-balance` / `get-usdt-balance` /
@@ -144,13 +134,8 @@ Error:
 }
 ```
 
-Additional rules:
-
-- Commands that broadcast a transaction include the transaction id as `txid` in `data`
-  (single-signature broadcasts only).
-- `deploy-contract` includes the deployed `contract_address` in `data`.
-- When an alias is resolved for an option, the envelope includes a `meta.resolved` array describing
-  the resolution (see the alias system in [Wallet Management](wallet-management.md)).
+Transaction commands may add identifiers such as `txid` or `contract_address` to `data`. Alias
+resolution details may appear under `meta.resolved` (see [Wallet Management](wallet-management.md)).
 
 Exit codes:
 
@@ -160,15 +145,12 @@ Exit codes:
 | `1` | Execution error (`"error": "execution_error"` and others). |
 | `2` | Usage error (`"error": "usage_error"` — bad flags, missing required option, etc.). |
 
-This makes the standard CLI safe to drive from scripts: check the exit code, and parse the single
-JSON object from stdout.
+For scripts, check the exit code and parse the JSON object from stdout.
 
 ## Networks and configuration
 
-The default node endpoints for each network, plus other defaults, live in
-`java/src/main/resources/config.conf` (HOCON format). The `--network` flag selects among `main`,
-`nile` (testnet), `shasta` (testnet), and `custom`. For `custom`, provide the endpoint with
-`--grpc-endpoint host:port`.
+The `--network` flag selects `main`, `nile` (testnet), `shasta` (testnet), or `custom`. For a custom
+network, provide the node endpoint with `--grpc-endpoint host:port`.
 
 In the REPL, use `SwitchNetwork` to change networks and `CurrentNetwork` to see the active one.
 

--- a/docs/clients/wallet-cli/staking.md
+++ b/docs/clients/wallet-cli/staking.md
@@ -15,12 +15,8 @@ Resource codes used throughout:
 | `1` | ENERGY |
 | `2` | TRON_POWER (voting power; freeze/unfreeze only, network-gated) |
 
-Code `2` (TRON_POWER) is network-gated for freeze/unfreeze commands:
-`FreezeBalance`/`UnfreezeBalance` (Stake 1.0), `FreezeBalanceV2`/`UnfreezeBalanceV2` (Stake 2.0),
-and their Standard CLI equivalents accept it only when the chain parameter
-`getAllowNewResourceModel` is enabled. If that chain parameter cannot be fetched, the client fails
-open and lets the node validate the transaction at broadcast. Delegation commands (both modes) always
-accept only `0` or `1`; TRON_POWER is not delegatable.
+Code `2` is available for freeze and unfreeze commands only when the network enables the new
+resource model. Delegation accepts only `0` or `1`; TRON_POWER cannot be delegated.
 
 Amounts are in **SUN** (1 TRX = 1,000,000 SUN).
 
@@ -45,9 +41,7 @@ resource queries at the end of the page do not.
     ```
 
     - `--amount` (required, SUN), `--duration` (required, days).
-    - `--resource` (optional, `0`/`1`/`2`, default `0`). `2` is TRON_POWER and is allowed only when
-      `getAllowNewResourceModel` is enabled. If `--receiver` is set, the operation is delegated and
-      `2` is rejected.
+    - `--resource` (optional, `0`/`1`/`2`, default `0`). With `--receiver`, use `0` or `1`.
     - `--receiver` (optional) — delegate the obtained resource to another address.
     - `--owner`, `--multi` (optional).
 
@@ -57,8 +51,6 @@ resource queries at the end of the page do not.
     FreezeBalance [OwnerAddress] frozen_balance frozen_duration [ResourceCode] [receiverAddress]
     ```
 
-    `ResourceCode`: `0` BANDWIDTH, `1` ENERGY, `2` TRON_POWER.
-
 ### Unfreeze balance — `unfreeze-balance` / `UnfreezeBalance`
 
 === "Standard CLI"
@@ -67,9 +59,7 @@ resource queries at the end of the page do not.
     java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
     ```
 
-    - `--resource` (optional, `0`/`1`/`2`, default `0`). `2` is TRON_POWER and is allowed only when
-      `getAllowNewResourceModel` is enabled. If `--receiver` is set, the operation targets a
-      delegated freeze and `2` is rejected.
+    - `--resource` (optional, `0`/`1`/`2`, default `0`). With `--receiver`, use `0` or `1`.
     - `--receiver` (optional) — required if the resource was delegated.
     - `--owner`, `--multi` (optional).
 
@@ -93,8 +83,6 @@ No duration: staked TRX stays staked until you explicitly unstake it.
     ```
 
     - `--amount` (required, SUN), `--resource` (optional, `0`/`1`/`2`, default `0`).
-      `2` is TRON_POWER and is allowed only when `getAllowNewResourceModel` is enabled; if that
-      chain parameter cannot be fetched, the client lets the node validate at broadcast.
     - `--owner`, `--permission-id`, `--multi` (optional).
 
 === "REPL"
@@ -116,8 +104,6 @@ waiting period (see `withdraw-expire-unfreeze`).
     ```
 
     - `--amount` (required, SUN), `--resource` (optional, `0`/`1`/`2`, default `0`).
-      `2` is TRON_POWER and is allowed only when `getAllowNewResourceModel` is enabled; if that
-      chain parameter cannot be fetched, the client lets the node validate at broadcast.
     - `--owner`, `--permission-id`, `--multi` (optional).
 
 === "REPL"
@@ -186,7 +172,7 @@ Lends staked bandwidth/energy to another account.
     DelegateResource [OwnerAddress] balance ResourceCode ReceiverAddress [lock] [lockPeriod]
     ```
 
-    `ResourceCode`: `0` BANDWIDTH, `1` ENERGY. `lock` is `true`/`false`.
+    `lock` is `true` or `false`.
 
 ### Undelegate resource — `undelegate-resource` / `UnDelegateResource`
 

--- a/docs/clients/wallet-cli/typescript-cli-gasfree.md
+++ b/docs/clients/wallet-cli/typescript-cli-gasfree.md
@@ -1,59 +1,46 @@
 # TypeScript CLI GasFree
 
-GasFree transfers let an account move supported tokens without holding TRX. The TypeScript CLI
-signs an EIP-712/TIP-712 authorization locally, and the GasFree provider relays the transfer and
-charges its fee in the transferred token.
+GasFree lets an account transfer supported tokens without holding TRX. The GasFree service submits
+the transfer and charges its fee in the transferred token.
 
-This workflow is separate from the Java CLI commands documented in [Java CLI GasFree](gasfree.md).
+This workflow is separate from the Java commands described in
+[Java CLI GasFree](gasfree.md).
 
-## Networks and credentials
+## Configure the service
 
-The TypeScript GasFree commands support TRON mainnet and Nile. Shasta is not supported. Configure
-API credentials that match the selected mainnet or testnet service environment:
+GasFree supports TRON mainnet and Nile; Shasta is not supported. Configure credentials for the
+selected mainnet or testnet environment:
 
 ```bash
 wallet-cli config gasfreeApiKey '<api-key>'
 wallet-cli config gasfreeApiSecret '<api-secret>'
 ```
 
-`gasfreeApiSecret` is masked in `wallet-cli config` text and JSON output; `gasfreeApiKey` is
-displayed. When the API secret is present, `config.yaml` must not be a symbolic link and must have
-no group or world permissions on POSIX; otherwise it is rejected with `insecure_config`. An
-unreadable or invalid configuration returns `invalid_config`.
+The API secret is masked when configuration is displayed. Keep `config.yaml` private; on POSIX,
+wallet-cli refuses to use an insecure configuration file that contains the secret.
 
-Missing credentials return `gasfree_credentials_missing`. Rejected credentials, including
-credentials for the wrong environment, return `gasfree_auth_failed`; rate limiting returns
-`provider_rate_limited`. Transport failures, malformed responses, and HTTP 5xx responses return
-`provider_error`. Other request or business rejection can return `gasfree_rejected`, while a
-missing provider resource returns `not_found`.
+## Find the GasFree address and fees
 
-## GasFree address and fees
+The GasFree service provides a dedicated address for each wallet account. Tokens used in this
+workflow must be sent to that address rather than the account's ordinary TRON address.
 
-For each wallet account, the GasFree service reports a dedicated GasFree address. The CLI obtains
-this address from the provider; it does not derive it locally. Assets used for GasFree transfers are
-held and sent from this address, not directly from the owner's ordinary TRON address. Query it
-together with activation state, nonce, supported tokens, and the provider's current fee schedule:
+Query the address, activation state, supported tokens, and current fees:
 
 ```bash
 wallet-cli gasfree info --account main --network tron:nile
 ```
 
-Give the returned GasFree address to a sender when the account needs to receive tokens for this
-workflow.
+The service charges:
 
-The provider deducts:
-
-- a per-transfer service fee; and
+- a fee for each transfer; and
 - a one-time activation fee on the first outgoing transfer from an inactive GasFree address.
 
-Both fees are charged in the token and are added to the requested transfer amount. The provider's
-supported-token list and fees are live configuration, so query or dry-run immediately before a
-transfer rather than hard-coding them.
+Both fees are paid in the token and added to the requested transfer amount. Fees and supported
+tokens can change, so query or dry-run immediately before transferring.
 
 ## Preview and submit a transfer
 
-Use `--dry-run` to retrieve fees, validate provider metadata, and check the token balance without
-unlocking the wallet or submitting an authorization:
+Use `--dry-run` to review the fees and check whether the GasFree address holds enough tokens:
 
 ```bash
 wallet-cli gasfree transfer \
@@ -64,10 +51,9 @@ wallet-cli gasfree transfer \
   --dry-run
 ```
 
-The balance must cover the amount plus the service fee and, when applicable, the activation fee.
-An insufficient balance returns `insufficient_token_balance`.
+The balance must cover the recipient amount plus the service fee and any activation fee.
 
-After reviewing the fee breakdown, sign and submit:
+After reviewing the result, sign and submit:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
@@ -79,80 +65,46 @@ printf '%s\n' "$WALLET_PASSWORD" |
     --password-stdin
 ```
 
-Ledger accounts also support GasFree signing. Do not pipe a password or pass `--password-stdin` for
-a Ledger account. Enable **Settings > Sign by Hash > Allowed** in the Ledger TRON app; otherwise the
-CLI returns `ledger_setting_required`. An app version without TIP-712 hash signing returns
-`ledger_unsupported`.
+`--to` also accepts a name stored with `contact add`.
 
-`--to` also accepts a name stored with `contact add`. The receipt includes `toContact` when a name
-was resolved.
+Ledger accounts support GasFree signing. Do not pass `--password-stdin` for a Ledger account, and
+enable **Settings > Sign by Hash > Allowed** in the Ledger TRON app.
 
-GasFree has no `--sign-only` or `--build-only` mode. Its signed authorization is bound to the
-provider submission protocol and is not a normal TRON transaction artifact for offline broadcast.
+GasFree does not support `--sign-only` or `--build-only`. Its authorization is submitted through
+the GasFree service rather than broadcast as a normal transaction artifact.
 
-## Track provider and chain state
+## Track the transfer
 
-Submission returns a provider `traceId`, not a transaction id. At this point the provider has
-accepted the request, but the transfer is not necessarily on-chain:
-
-```json
-{
-  "kind": "gasfree-transfer",
-  "stage": "submitted",
-  "traceId": "7f3e9a02-58c1-4d2e-b6a4-91d0c3f8e527"
-}
-```
-
-Either add `--wait` to the original transfer or query it later:
+Submission returns a GasFree `traceId`, not an on-chain transaction id. The transfer may still be
+waiting for the service or the network:
 
 ```bash
-wallet-cli gasfree trace \
-  7f3e9a02-58c1-4d2e-b6a4-91d0c3f8e527 \
-  --network tron:nile
+wallet-cli gasfree trace <TRACE_ID> --network tron:nile
 ```
 
-The non-terminal provider states are ordered as follows:
+You can also add `--wait` to `gasfree transfer`.
 
-```text
-WAITING → INPROGRESS → CONFIRMING
-```
+The service reports progress through `WAITING`, `INPROGRESS`, and `CONFIRMING`.
+`SUCCEED` and `FAILED` are terminal states. Polling may skip intermediate states.
 
-`SUCCEED` and `FAILED` are terminal states. Polling observes snapshots and may skip one or more
-intermediate states, so automation must not require every state to appear.
+Do not pass a GasFree trace id to `tx status`. Continue using `gasfree trace` until the service
+returns a terminal state. An on-chain transaction id appears after the service submits the
+transaction.
 
-An on-chain `txId` appears only after the provider submits the transaction. Do not pass a GasFree
-`traceId` to `tx status`; use `gasfree trace` until the provider returns a terminal state.
+For automation, inspect the returned `state` or `stage`. A successful status query can still
+report a failed transfer.
 
-A failed provider transfer is still a successful status query: `gasfree trace` exits `0` with
-`success: true`, while `data.state` is `FAILED`. When the provider supplies an explanation, it is
-returned as `data.failureReason`. Similarly, `gasfree transfer --wait` reports
-`data.stage: "failed"`. Automation must branch on these data fields rather than the command exit
-code alone.
+## Checklist
 
-## Integrity and signing checks
+- Use `gasfree info` to obtain the correct receiving address and current fees.
+- Keep mainnet and Nile credentials separate.
+- Dry-run immediately before sending.
+- Confirm the balance covers the amount and all fees.
+- Treat a submitted request as pending until it reaches a terminal state.
+- On mainnet, confirm the recipient, token, amount, and fee before signing.
 
-Before submission, wallet-cli:
-
-- validates supported-token and fee metadata returned by the provider;
-- checks amount plus all applicable fees against the GasFree token balance;
-- recomputes the typed-data digest;
-- signs locally and recovers the signer address from the signature;
-- rejects a signature that does not match the selected account.
-
-Metadata inconsistency returns `gasfree_integrity`, signing mismatch or refusal returns
-`signing_rejected`, and provider rejection returns `gasfree_rejected`. Watch-only accounts return
-`watch_only_no_signer` before signing.
-
-## Operational checklist
-
-- Use `gasfree info` to obtain the correct receiving address and current fee schedule.
-- Keep mainnet and Nile API credentials separate and switch them when changing environments.
-- Dry-run immediately before sending, especially for an inactive GasFree address.
-- Confirm `amount + serviceFee + activateFee`, not just the recipient amount.
-- Treat `stage: "submitted"` as provider acceptance, not chain confirmation.
-- On mainnet, confirm the recipient, token, amount, and fee with the user before signing.
-
-For complete fields and error codes, see the upstream references for
+For all options and response fields, see the upstream references for
 [`gasfree info`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/info.md),
 [`gasfree transfer`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/transfer.md),
-and [`gasfree trace`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/trace.md).
+and
+[`gasfree trace`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/trace.md).

--- a/docs/clients/wallet-cli/typescript-cli-gasfree.md
+++ b/docs/clients/wallet-cli/typescript-cli-gasfree.md
@@ -1,0 +1,158 @@
+# TypeScript CLI GasFree
+
+GasFree transfers let an account move supported tokens without holding TRX. The TypeScript CLI
+signs an EIP-712/TIP-712 authorization locally, and the GasFree provider relays the transfer and
+charges its fee in the transferred token.
+
+This workflow is separate from the Java CLI commands documented in [Java CLI GasFree](gasfree.md).
+
+## Networks and credentials
+
+The TypeScript GasFree commands support TRON mainnet and Nile. Shasta is not supported. Configure
+API credentials that match the selected mainnet or testnet service environment:
+
+```bash
+wallet-cli config gasfreeApiKey '<api-key>'
+wallet-cli config gasfreeApiSecret '<api-secret>'
+```
+
+`gasfreeApiSecret` is masked in `wallet-cli config` text and JSON output; `gasfreeApiKey` is
+displayed. When the API secret is present, `config.yaml` must not be a symbolic link and must have
+no group or world permissions on POSIX; otherwise it is rejected with `insecure_config`. An
+unreadable or invalid configuration returns `invalid_config`.
+
+Missing credentials return `gasfree_credentials_missing`. Rejected credentials, including
+credentials for the wrong environment, return `gasfree_auth_failed`; rate limiting returns
+`provider_rate_limited`. Transport failures, malformed responses, and HTTP 5xx responses return
+`provider_error`. Other request or business rejection can return `gasfree_rejected`, while a
+missing provider resource returns `not_found`.
+
+## GasFree address and fees
+
+For each wallet account, the GasFree service reports a dedicated GasFree address. The CLI obtains
+this address from the provider; it does not derive it locally. Assets used for GasFree transfers are
+held and sent from this address, not directly from the owner's ordinary TRON address. Query it
+together with activation state, nonce, supported tokens, and the provider's current fee schedule:
+
+```bash
+wallet-cli gasfree info --account main --network tron:nile
+```
+
+Give the returned GasFree address to a sender when the account needs to receive tokens for this
+workflow.
+
+The provider deducts:
+
+- a per-transfer service fee; and
+- a one-time activation fee on the first outgoing transfer from an inactive GasFree address.
+
+Both fees are charged in the token and are added to the requested transfer amount. The provider's
+supported-token list and fees are live configuration, so query or dry-run immediately before a
+transfer rather than hard-coding them.
+
+## Preview and submit a transfer
+
+Use `--dry-run` to retrieve fees, validate provider metadata, and check the token balance without
+unlocking the wallet or submitting an authorization:
+
+```bash
+wallet-cli gasfree transfer \
+  --to TRecipient... \
+  --amount 25 \
+  --token USDT \
+  --network tron:nile \
+  --dry-run
+```
+
+The balance must cover the amount plus the service fee and, when applicable, the activation fee.
+An insufficient balance returns `insufficient_token_balance`.
+
+After reviewing the fee breakdown, sign and submit:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli gasfree transfer \
+    --to TRecipient... \
+    --amount 25 \
+    --token USDT \
+    --network tron:nile \
+    --password-stdin
+```
+
+Ledger accounts also support GasFree signing. Do not pipe a password or pass `--password-stdin` for
+a Ledger account. Enable **Settings > Sign by Hash > Allowed** in the Ledger TRON app; otherwise the
+CLI returns `ledger_setting_required`. An app version without TIP-712 hash signing returns
+`ledger_unsupported`.
+
+`--to` also accepts a name stored with `contact add`. The receipt includes `toContact` when a name
+was resolved.
+
+GasFree has no `--sign-only` or `--build-only` mode. Its signed authorization is bound to the
+provider submission protocol and is not a normal TRON transaction artifact for offline broadcast.
+
+## Track provider and chain state
+
+Submission returns a provider `traceId`, not a transaction id. At this point the provider has
+accepted the request, but the transfer is not necessarily on-chain:
+
+```json
+{
+  "kind": "gasfree-transfer",
+  "stage": "submitted",
+  "traceId": "7f3e9a02-58c1-4d2e-b6a4-91d0c3f8e527"
+}
+```
+
+Either add `--wait` to the original transfer or query it later:
+
+```bash
+wallet-cli gasfree trace \
+  7f3e9a02-58c1-4d2e-b6a4-91d0c3f8e527 \
+  --network tron:nile
+```
+
+The non-terminal provider states are ordered as follows:
+
+```text
+WAITING → INPROGRESS → CONFIRMING
+```
+
+`SUCCEED` and `FAILED` are terminal states. Polling observes snapshots and may skip one or more
+intermediate states, so automation must not require every state to appear.
+
+An on-chain `txId` appears only after the provider submits the transaction. Do not pass a GasFree
+`traceId` to `tx status`; use `gasfree trace` until the provider returns a terminal state.
+
+A failed provider transfer is still a successful status query: `gasfree trace` exits `0` with
+`success: true`, while `data.state` is `FAILED`. When the provider supplies an explanation, it is
+returned as `data.failureReason`. Similarly, `gasfree transfer --wait` reports
+`data.stage: "failed"`. Automation must branch on these data fields rather than the command exit
+code alone.
+
+## Integrity and signing checks
+
+Before submission, wallet-cli:
+
+- validates supported-token and fee metadata returned by the provider;
+- checks amount plus all applicable fees against the GasFree token balance;
+- recomputes the typed-data digest;
+- signs locally and recovers the signer address from the signature;
+- rejects a signature that does not match the selected account.
+
+Metadata inconsistency returns `gasfree_integrity`, signing mismatch or refusal returns
+`signing_rejected`, and provider rejection returns `gasfree_rejected`. Watch-only accounts return
+`watch_only_no_signer` before signing.
+
+## Operational checklist
+
+- Use `gasfree info` to obtain the correct receiving address and current fee schedule.
+- Keep mainnet and Nile API credentials separate and switch them when changing environments.
+- Dry-run immediately before sending, especially for an inactive GasFree address.
+- Confirm `amount + serviceFee + activateFee`, not just the recipient amount.
+- Treat `stage: "submitted"` as provider acceptance, not chain confirmation.
+- On mainnet, confirm the recipient, token, amount, and fee with the user before signing.
+
+For complete fields and error codes, see the upstream references for
+[`gasfree info`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/info.md),
+[`gasfree transfer`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/transfer.md),
+and [`gasfree trace`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/trace.md).

--- a/docs/clients/wallet-cli/typescript-cli-multisig.md
+++ b/docs/clients/wallet-cli/typescript-cli-multisig.md
@@ -1,27 +1,28 @@
 # TypeScript CLI multi-signature
 
-The TypeScript CLI supports the full TRON multi-signature lifecycle: inspect or replace account
-permissions, build a transaction for a selected permission, collect weighted signatures, verify the
-threshold, and broadcast. Signatures can be exchanged directly as a hex artifact or collected by
-the optional TronLink multi-signature service.
+The TypeScript CLI can inspect and replace account permissions, build a transaction for a selected
+permission, collect weighted signatures, and broadcast after the threshold is reached.
 
-## Permission model and fees
+Signers can exchange a transaction file directly or use the optional TronLink multi-signature
+service.
 
-Every TRON account has:
+## Permissions and fees
 
-- one owner permission, id `0`, with full control;
-- an optional witness permission, id `1`, for Super Representatives;
-- up to eight active permissions, ids `2`–`9`, scoped to selected contract operations.
+A TRON account can have:
 
-A permission contains up to five keys. Each key has a weight, and signatures authorize a
-transaction when their combined weight reaches the permission's threshold.
+- one owner permission, id `0`;
+- an optional witness permission, id `1`; and
+- up to eight active permissions, ids `2`–`9`.
 
-Two chain-set fees are especially important. wallet-cli reads their current values at runtime:
+Each permission can contain up to five keys. Every key has a weight, and the combined weight of the
+signatures must reach the permission threshold.
 
-- replacing an account's permission structure burns the permission-update fee, currently **100
-  TRX on mainnet**;
-- broadcasting a transaction with more than one signature incurs the additional multi-signature
-  fee, currently **1 TRX on mainnet**.
+Two chain fees are especially relevant:
+
+- replacing the account's permission structure currently costs **100 TRX on mainnet**; and
+- broadcasting a transaction with more than one signature currently adds **1 TRX on mainnet**.
+
+These are chain parameters and can change. wallet-cli reads the current values at runtime.
 
 ## Inspect and update permissions
 
@@ -32,18 +33,13 @@ wallet-cli permission show --account main --network tron:nile
 wallet-cli permission show --account main --network tron:nile --output json
 ```
 
-`permission show` lists owner, witness, and active groups; thresholds; weighted keys; decoded active
-operations; and which keys are held by the local wallet. A bare address is also accepted, so the
-account does not need to be imported locally for this read-only query.
-
-`permission update` replaces the entire structure. Export the current data, edit it, and dry-run the
-replacement before signing:
+`permission update` replaces the complete permission structure. Export the current structure,
+edit only the intended fields, and dry-run the replacement:
 
 ```bash
 wallet-cli permission show --account main --network tron:nile --output json |
   jq '.data' > permissions.json
 
-# Edit keys, weights, thresholds, names, and operations.
 $EDITOR permissions.json
 
 wallet-cli permission update \
@@ -53,16 +49,11 @@ wallet-cli permission update \
   --dry-run
 ```
 
-Each active permission contains decoded `operations`, its raw `operationsHex`, and
-`unknownOperationIds` for bitmap bits that this wallet-cli version cannot name. If
-`unknownOperationIds` is empty, edit `operations` and remove that group's old `operationsHex`;
-wallet-cli will regenerate the bitmap. If `unknownOperationIds` is non-empty, `operations` alone
-cannot preserve those bits. To keep them, retain `unknownOperationIds` and update `operationsHex`
-consistently with both the named and unknown operations. To remove them deliberately, remove or
-empty `unknownOperationIds` and remove `operationsHex`, so wallet-cli regenerates a bitmap from the
-named `operations` only. If the fields disagree, the update is rejected with `invalid_permission`.
-
-After reviewing the complete resulting structure and fee, submit it:
+Preserve fields you do not intend to change and review the complete dry-run result. When changing
+allowed operations, follow the upstream [`permission` reference](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands/permission),
+because the related fields must remain consistent. If `permission show` reports unknown operations,
+leave that active permission unchanged unless you can preserve its bitmap. After checking the keys,
+weights, threshold, allowed operations, and fee, submit the update:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
@@ -75,20 +66,17 @@ printf '%s\n' "$WALLET_PASSWORD" |
 ```
 
 !!! danger
-    A permission update can permanently lock an account, and there is no on-chain recovery. The
-    chain accepts an owner group even if none of its keys are locally available or its threshold
-    requires unavailable co-signers. wallet-cli emits `owner_lockout` or
-    `owner_lockout_partial` warnings but does not block a deliberately multi-party setup. It also
-    warns when an active permission can itself update permissions.
+    A permission update can permanently lock an account, and there is no on-chain recovery. Confirm
+    that the new owner permission contains the intended keys and that available signers can reach
+    its threshold.
 
-## Direct artifact workflow
+## Exchange a transaction file
 
-The service-free workflow passes one transaction hex between signers.
+The direct workflow does not require an external collaboration service.
 
-### 1. Start the artifact
+### 1. Create the first artifact
 
-The initiator selects the permission group, extends the expiration, and produces the first
-signature:
+Select the permission, allow enough time for co-signers, and create the first signature:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
@@ -103,26 +91,22 @@ printf '%s\n' "$WALLET_PASSWORD" |
     --output text > transaction.hex
 ```
 
-The default transaction expiration is approximately 60 seconds. Use an explicit expiration, up to
-24 hours, when signatures will be collected manually.
-
-`--build-only` can instead produce an unsigned artifact without unlocking a wallet. This is useful
-when the first signer is on another machine or when opening a TronLink service collection.
+The default transaction expiration is approximately 60 seconds. For manual collection, set an
+expiration long enough for every signer, up to 24 hours. Use `--build-only` instead of
+`--sign-only` when the first signer is on another machine.
 
 ### 2. Inspect approvals
-
-Anyone with the artifact can inspect its permission, current weight, approved signers, missing
-weight, and expiration without signing or unlocking a wallet:
 
 ```bash
 wallet-cli tx approvals --file transaction.hex --network tron:nile
 ```
 
-An expired transaction remains inspectable but cannot be signed or broadcast.
+This shows the permission, approved signers, accumulated and missing weight, and expiration. An
+expired transaction can be inspected but not signed or broadcast.
 
-### 3. Append signatures
+### 3. Add signatures
 
-Each remaining signer appends exactly one signature while preserving the previous ones:
+Each signer uses the latest file produced by the previous signer:
 
 ```bash
 printf '%s\n' "$COSIGNER_PASSWORD" |
@@ -134,30 +118,24 @@ printf '%s\n' "$COSIGNER_PASSWORD" |
     --password-stdin
 ```
 
-Pass the resulting file to the next signer. Online signing verifies permission membership and
-rejects duplicate signatures before decrypting the key. On an air-gapped machine, add `--offline`;
-the node-backed weight check can be repeated later with `tx approvals`.
+Online signing checks permission membership and rejects duplicate signatures. On an air-gapped
+machine, add `--offline` and check the artifact later with `tx approvals`.
 
 ### 4. Validate and broadcast
 
-After `thresholdReached` is true, validate without submission and then broadcast:
+When `thresholdReached` is true, validate and broadcast the final artifact:
 
 ```bash
 wallet-cli tx broadcast --file transaction.signed.hex --network tron:nile --dry-run
 wallet-cli tx broadcast --file transaction.signed.hex --network tron:nile --wait
 ```
 
-`tx broadcast` refuses an expired artifact (`tx_expired`) locally and uses the node's read-only
-permission endpoints to reject one below its threshold (`not_authorized`). An incomplete
-transaction is therefore never submitted to the node's broadcast endpoint.
+wallet-cli refuses an expired transaction or one whose signature weight is below the threshold.
 
-## TronLink service collaboration
+## Use the TronLink service
 
-`tx multisig` is an optional convenience layer. The TronLink service stores a transaction,
-accumulates signatures, and notifies co-signers over WebSocket. The direct artifact workflow above
-does not require this service.
-
-Configure credentials matching the selected mainnet or testnet environment:
+`tx multisig` can store the transaction, coordinate signatures, and notify co-signers. Configure
+credentials that match the selected mainnet or testnet environment:
 
 ```bash
 wallet-cli config tronlinkSecretId '<secret-id>'
@@ -165,7 +143,7 @@ wallet-cli config tronlinkSecretKey '<secret-key>'
 wallet-cli config tronlinkChannel '<channel>'
 ```
 
-Build an unsigned artifact, then sign it locally and open a collection:
+Build an unsigned artifact and create a collection:
 
 ```bash
 wallet-cli tx send \
@@ -185,8 +163,8 @@ printf '%s\n' "$WALLET_PASSWORD" |
     --password-stdin
 ```
 
-Opening a collection adds the initiator's first signature; there is no empty collection. Other
-signers list work awaiting them and sign by transaction id:
+Creating a collection adds the initiator's first signature. Other signers can list requests and sign
+by transaction id:
 
 ```bash
 wallet-cli tx multisig --account cosigner --network tron:nile
@@ -199,27 +177,23 @@ printf '%s\n' "$COSIGNER_PASSWORD" |
     --password-stdin
 ```
 
-Use `tx multisig --watch` to receive only the count of transactions awaiting the selected account;
-transaction content is not included in notifications. When the threshold is reached, the service
-broadcasts automatically. Confirm the transaction on-chain before attempting the manual
-`tx broadcast` fallback.
+Use `tx multisig --watch` to receive notifications. The service broadcasts automatically when the
+threshold is reached. Confirm the transaction on-chain before attempting a manual broadcast.
 
 ## Safety checklist
 
-- Run `permission show` before selecting a permission or editing its keys.
-- Always `--dry-run` and manually review a full permission replacement.
-- Pass the newly signed artifact to the next signer. Its transaction body (`raw_data` and
-  `raw_data_hex`) and `txID` must remain unchanged while the signature array grows; changing the
-  transaction body invalidates all prior signatures.
+- Inspect current permissions before selecting or changing one.
+- Dry-run and review the complete permission replacement.
+- Pass only the latest artifact to the next signer; changing the transaction invalidates earlier
+  signatures.
 - Choose an expiration long enough for collection but no longer than necessary.
-- Check `thresholdReached`, not the number of signatures: signer weights may differ.
-- Treat TronLink responses as third-party data. wallet-cli re-derives and cross-checks transaction
-  identity, owner, contract type, weights, and signature progress before signing.
-- On mainnet, obtain explicit approval before updating permissions or broadcasting a transaction.
+- Check `thresholdReached`, not the number of signatures, because weights can differ.
+- Confirm the recipient, amount, permission, and fee before signing or broadcasting on mainnet.
 
-For complete command fields and error codes, see the upstream references for
+For all options and response fields, see the upstream references for
 [`permission`](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands/permission),
 [`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md),
 [`tx approvals`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/approvals.md),
 [`tx multisig`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/multisig.md),
-and [`tx broadcast`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/broadcast.md).
+and
+[`tx broadcast`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/broadcast.md).

--- a/docs/clients/wallet-cli/typescript-cli-multisig.md
+++ b/docs/clients/wallet-cli/typescript-cli-multisig.md
@@ -1,0 +1,225 @@
+# TypeScript CLI multi-signature
+
+The TypeScript CLI supports the full TRON multi-signature lifecycle: inspect or replace account
+permissions, build a transaction for a selected permission, collect weighted signatures, verify the
+threshold, and broadcast. Signatures can be exchanged directly as a hex artifact or collected by
+the optional TronLink multi-signature service.
+
+## Permission model and fees
+
+Every TRON account has:
+
+- one owner permission, id `0`, with full control;
+- an optional witness permission, id `1`, for Super Representatives;
+- up to eight active permissions, ids `2`–`9`, scoped to selected contract operations.
+
+A permission contains up to five keys. Each key has a weight, and signatures authorize a
+transaction when their combined weight reaches the permission's threshold.
+
+Two chain-set fees are especially important. wallet-cli reads their current values at runtime:
+
+- replacing an account's permission structure burns the permission-update fee, currently **100
+  TRX on mainnet**;
+- broadcasting a transaction with more than one signature incurs the additional multi-signature
+  fee, currently **1 TRX on mainnet**.
+
+## Inspect and update permissions
+
+Inspect an account before creating or signing a transaction:
+
+```bash
+wallet-cli permission show --account main --network tron:nile
+wallet-cli permission show --account main --network tron:nile --output json
+```
+
+`permission show` lists owner, witness, and active groups; thresholds; weighted keys; decoded active
+operations; and which keys are held by the local wallet. A bare address is also accepted, so the
+account does not need to be imported locally for this read-only query.
+
+`permission update` replaces the entire structure. Export the current data, edit it, and dry-run the
+replacement before signing:
+
+```bash
+wallet-cli permission show --account main --network tron:nile --output json |
+  jq '.data' > permissions.json
+
+# Edit keys, weights, thresholds, names, and operations.
+$EDITOR permissions.json
+
+wallet-cli permission update \
+  --file permissions.json \
+  --account main \
+  --network tron:nile \
+  --dry-run
+```
+
+Each active permission contains decoded `operations`, its raw `operationsHex`, and
+`unknownOperationIds` for bitmap bits that this wallet-cli version cannot name. If
+`unknownOperationIds` is empty, edit `operations` and remove that group's old `operationsHex`;
+wallet-cli will regenerate the bitmap. If `unknownOperationIds` is non-empty, `operations` alone
+cannot preserve those bits. To keep them, retain `unknownOperationIds` and update `operationsHex`
+consistently with both the named and unknown operations. To remove them deliberately, remove or
+empty `unknownOperationIds` and remove `operationsHex`, so wallet-cli regenerates a bitmap from the
+named `operations` only. If the fields disagree, the update is rejected with `invalid_permission`.
+
+After reviewing the complete resulting structure and fee, submit it:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli permission update \
+    --file permissions.json \
+    --account main \
+    --network tron:nile \
+    --wait \
+    --password-stdin
+```
+
+!!! danger
+    A permission update can permanently lock an account, and there is no on-chain recovery. The
+    chain accepts an owner group even if none of its keys are locally available or its threshold
+    requires unavailable co-signers. wallet-cli emits `owner_lockout` or
+    `owner_lockout_partial` warnings but does not block a deliberately multi-party setup. It also
+    warns when an active permission can itself update permissions.
+
+## Direct artifact workflow
+
+The service-free workflow passes one transaction hex between signers.
+
+### 1. Start the artifact
+
+The initiator selects the permission group, extends the expiration, and produces the first
+signature:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx send \
+    --to TRecipient... \
+    --amount 1000 \
+    --permission-id 2 \
+    --sign-only \
+    --expiration 86400000 \
+    --network tron:nile \
+    --password-stdin \
+    --output text > transaction.hex
+```
+
+The default transaction expiration is approximately 60 seconds. Use an explicit expiration, up to
+24 hours, when signatures will be collected manually.
+
+`--build-only` can instead produce an unsigned artifact without unlocking a wallet. This is useful
+when the first signer is on another machine or when opening a TronLink service collection.
+
+### 2. Inspect approvals
+
+Anyone with the artifact can inspect its permission, current weight, approved signers, missing
+weight, and expiration without signing or unlocking a wallet:
+
+```bash
+wallet-cli tx approvals --file transaction.hex --network tron:nile
+```
+
+An expired transaction remains inspectable but cannot be signed or broadcast.
+
+### 3. Append signatures
+
+Each remaining signer appends exactly one signature while preserving the previous ones:
+
+```bash
+printf '%s\n' "$COSIGNER_PASSWORD" |
+  wallet-cli tx sign \
+    --file transaction.hex \
+    --account cosigner \
+    --network tron:nile \
+    --out transaction.signed.hex \
+    --password-stdin
+```
+
+Pass the resulting file to the next signer. Online signing verifies permission membership and
+rejects duplicate signatures before decrypting the key. On an air-gapped machine, add `--offline`;
+the node-backed weight check can be repeated later with `tx approvals`.
+
+### 4. Validate and broadcast
+
+After `thresholdReached` is true, validate without submission and then broadcast:
+
+```bash
+wallet-cli tx broadcast --file transaction.signed.hex --network tron:nile --dry-run
+wallet-cli tx broadcast --file transaction.signed.hex --network tron:nile --wait
+```
+
+`tx broadcast` refuses an expired artifact (`tx_expired`) locally and uses the node's read-only
+permission endpoints to reject one below its threshold (`not_authorized`). An incomplete
+transaction is therefore never submitted to the node's broadcast endpoint.
+
+## TronLink service collaboration
+
+`tx multisig` is an optional convenience layer. The TronLink service stores a transaction,
+accumulates signatures, and notifies co-signers over WebSocket. The direct artifact workflow above
+does not require this service.
+
+Configure credentials matching the selected mainnet or testnet environment:
+
+```bash
+wallet-cli config tronlinkSecretId '<secret-id>'
+wallet-cli config tronlinkSecretKey '<secret-key>'
+wallet-cli config tronlinkChannel '<channel>'
+```
+
+Build an unsigned artifact, then sign it locally and open a collection:
+
+```bash
+wallet-cli tx send \
+  --to TRecipient... \
+  --amount 1000 \
+  --permission-id 2 \
+  --build-only \
+  --expiration 86400000 \
+  --network tron:nile \
+  --output text > transaction.unsigned.hex
+
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx multisig \
+    --create \
+    --file transaction.unsigned.hex \
+    --network tron:nile \
+    --password-stdin
+```
+
+Opening a collection adds the initiator's first signature; there is no empty collection. Other
+signers list work awaiting them and sign by transaction id:
+
+```bash
+wallet-cli tx multisig --account cosigner --network tron:nile
+
+printf '%s\n' "$COSIGNER_PASSWORD" |
+  wallet-cli tx multisig \
+    --sign <TX_ID> \
+    --account cosigner \
+    --network tron:nile \
+    --password-stdin
+```
+
+Use `tx multisig --watch` to receive only the count of transactions awaiting the selected account;
+transaction content is not included in notifications. When the threshold is reached, the service
+broadcasts automatically. Confirm the transaction on-chain before attempting the manual
+`tx broadcast` fallback.
+
+## Safety checklist
+
+- Run `permission show` before selecting a permission or editing its keys.
+- Always `--dry-run` and manually review a full permission replacement.
+- Pass the newly signed artifact to the next signer. Its transaction body (`raw_data` and
+  `raw_data_hex`) and `txID` must remain unchanged while the signature array grows; changing the
+  transaction body invalidates all prior signatures.
+- Choose an expiration long enough for collection but no longer than necessary.
+- Check `thresholdReached`, not the number of signatures: signer weights may differ.
+- Treat TronLink responses as third-party data. wallet-cli re-derives and cross-checks transaction
+  identity, owner, contract type, weights, and signature progress before signing.
+- On mainnet, obtain explicit approval before updating permissions or broadcasting a transaction.
+
+For complete command fields and error codes, see the upstream references for
+[`permission`](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands/permission),
+[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md),
+[`tx approvals`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/approvals.md),
+[`tx multisig`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/multisig.md),
+and [`tx broadcast`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/broadcast.md).

--- a/docs/clients/wallet-cli/typescript-cli-signing.md
+++ b/docs/clients/wallet-cli/typescript-cli-signing.md
@@ -1,40 +1,30 @@
 # TypeScript CLI signing and security
 
-The TypeScript CLI supports software keystores, Ledger accounts, and watch-only accounts. Software
-private keys stay encrypted locally, Ledger private keys never leave the device, and watch-only
-accounts can query state but cannot sign.
+The TypeScript CLI supports software, Ledger, and watch-only accounts. Software keys remain
+encrypted locally, Ledger keys stay on the device, and watch-only accounts cannot sign.
 
-## Transaction signing modes
+## Sign a transaction
 
-`tx sign` accepts two transaction representations with different purposes:
+`tx sign` accepts two forms of input:
 
-| Input | Purpose | Network behavior |
-|-------|---------|------------------|
-| `--transaction <json>` | Compatibility path for signing one unsigned JSON transaction | Offline for a software account; `--network` is optional |
-| `--hex <hex>` / `--file <path>` | Append one signature to an unsigned or partially signed artifact | Checks permission membership and approval weight online by default; `--offline` disables those checks |
+| Input | Use |
+|-------|-----|
+| `--transaction <json>` | Sign a JSON transaction directly. |
+| `--hex <hex>` / `--file <path>` | Add a signature to a transaction artifact. |
 
-The command never broadcasts. Use `tx broadcast` after signing.
+The command signs but never broadcasts. Use `tx broadcast` afterward.
 
-### Sign unsigned JSON
-
-The JSON compatibility path signs a transaction built elsewhere and returns the same `data.signed`
-shape as a transaction-building command in `--sign-only` mode:
+For a software account, provide the password through stdin:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
   wallet-cli tx sign \
     --transaction "$TX_JSON" \
-    --password-stdin \
-    --output json
+    --password-stdin
 ```
 
-This is a direct single-signature path. The caller remains responsible for deciding who should sign
-and whether the operation is desirable; wallet-cli verifies payload integrity before using the key.
-
-### Append a signature to a hex artifact
-
-For multi-signature transactions, use `--hex` or `--file`. Existing signatures are preserved and
-exactly one signature from the selected account is appended:
+For a multi-signature artifact, existing signatures are preserved and the selected account adds one
+signature:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
@@ -46,62 +36,25 @@ printf '%s\n' "$WALLET_PASSWORD" |
     --password-stdin
 ```
 
-Before decrypting a software key, the default online mode asks the node for the transaction's
-permission group and refuses when:
+By default, artifact signing checks the selected permission and existing approvals online. It
+refuses an expired transaction, an unauthorized signer, or a duplicate signature. Use `--offline`
+on an air-gapped machine, then inspect the artifact later with `tx approvals`.
 
-- the selected account is not a key in the group (`not_authorized`);
-- that account has already signed (`already_signed`);
-- the transaction has expired (`tx_expired`).
-
-The result reports the signer's weight, accumulated weight, missing weight, whether the threshold
-has been reached, and the new transaction hex. `tx sign` has no `--permission-id`: the permission id
-is already part of the transaction body and cannot change between signers.
-
-Use `--offline` with `--hex` or `--file` on an air-gapped signing machine. It skips permission and
-approval lookups but retains local decoding and integrity checks. The receipt then reports a
-signature count rather than authoritative weight; inspect the artifact later with `tx approvals`.
-`--out` writes the resulting artifact atomically with mode `0644`. A signed transaction is not a
-secret, although its contents should still be reviewed before distribution.
-
-For the end-to-end permission, co-signing, and broadcast sequence, see
+For the complete co-signing workflow, see
 [TypeScript CLI multi-signature](typescript-cli-multisig.md).
 
-## Transaction integrity
+## Review before signing
 
-A TRON transaction represents its content in three related fields:
+wallet-cli validates the transaction representation before signing. Hex and file artifacts are
+refused when they cannot be safely decoded and verified.
 
-| Field | Purpose |
-|-------|---------|
-| `raw_data` | Human- and application-readable transaction content |
-| `raw_data_hex` | Bytes executed by the node |
-| `txID` | SHA-256 hash covered by every signature |
-
-Before signing, wallet-cli requires `txID` to equal the SHA-256 hash of `raw_data_hex`. It decodes
-the outer transaction envelope and requires the contract types declared in `raw_data` to match the
-encoded bytes. For contract types that can be re-encoded, it also requires the field-level content
-of `raw_data` to produce the same bytes. A mismatch returns `tx_integrity` and no signature is
-produced.
-
-Six contract types cannot be re-encoded by TronWeb for the field-level integrity comparison:
-
-- `VoteAssetContract`
-- `UnfreezeAssetContract`
-- `CustomContract`
-- `ShieldedTransferContract`
-- `MarketSellAssetContract`
-- `MarketCancelOrderContract`
-
-Hex/file input containing any of these contracts is rejected with `invalid_transaction`, because
-the artifact cannot be displayed and verified completely. `VoteAssetContract` and `CustomContract`
-are rejected as unsupported contract type ids; the other four are rejected because they cannot be
-decoded losslessly. The JSON compatibility path can sign all six after checking the transaction
-hash and contract type, but their displayed `raw_data` field values cannot be independently verified
-against `raw_data_hex`.
+Always confirm the sender, recipient, amount, token or contract, permission, and expiration before
+signing. For offline signing, transfer the artifact through a trusted channel and do not modify its
+transaction content between signers.
 
 ## Sign typed data
 
-`typed-data sign` signs EIP-712/TIP-712 structured data and returns the signer address, inferred or
-declared primary type, digest, and signature:
+`typed-data sign` signs EIP-712/TIP-712 structured data:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
@@ -111,92 +64,53 @@ printf '%s\n' "$WALLET_PASSWORD" |
     --output json
 ```
 
-The payload follows the usual `domain`, `types`, `primaryType`, and `message` structure. The CLI:
+The payload uses `domain`, `types`, `primaryType`, and `message`. TRON Base58 addresses are
+accepted in address fields. The value of `domain.chainId` is signed as supplied and is not checked
+against `--network`, so review both the domain and message carefully.
 
-- ignores `EIP712Domain` when it appears inside `types`;
-- accepts `value` as an alias for `message`;
-- accepts TRON Base58 addresses in `address` fields;
-- infers `primaryType` when omitted and reports the resolved type;
-- rejects a declared `primaryType` that is not the root message type.
+## Ledger accounts
 
-`domain.chainId` is signed exactly as supplied and is not compared with `--network`. Review the
-domain and message before signing.
+Ledger accounts support transaction and typed-data signing. Do not pipe a password or pass
+`--password-stdin` when using one.
 
-## Ledger behavior
+For typed data, enable **Settings > Sign by Hash > Allowed** in the Ledger TRON app. The device may
+show hashes instead of every typed-data field, so verify the complete payload on the host before
+approving it.
 
-Both `tx sign` and `typed-data sign` support Ledger accounts. Transaction-integrity checks run
-before software and Ledger signing alike. Do not pass `--password-stdin` for a Ledger account.
+Other operations may require the corresponding transaction or custom-contract signing setting in
+the TRON app. If the app or device cannot sign an operation, wallet-cli returns an actionable Ledger
+error.
 
-Typed-data signing uses the TRON application's hash-signing capability. Enable
-**Settings > Sign by Hash > Allowed** on the device. Otherwise the CLI returns
-`ledger_setting_required`. A TRON application version that does not support the instruction returns
-`ledger_unsupported`.
+## Password and secret input
 
-Other Ledger application settings, such as transaction data or custom-contract signing, are also
-reported as actionable `ledger_setting_required` errors instead of an opaque APDU error. A device
-timeout or cancellation closes the transport so a later attempt can reconnect cleanly.
+Master passwords, mnemonics, and private keys are never accepted as command-line arguments or
+configuration values.
 
-The Ledger screen cannot render every typed-data field and may show only hashes. Verify the payload
-on the host before approving it on the device.
+Signing with a software account requires `--password-stdin`. Commands without an explicit
+interactive password flow do not prompt when the password flag is missing.
 
-## Secret input policy
-
-Wallet secrets — master passwords, mnemonics, and private keys — are never accepted as command-line
-arguments or environment configuration. Supported stdin channels are:
-
-Signing with a software account requires the master password through `--password-stdin`. Commands
-without an explicit interactive password flow never prompt for a missing password, even when run
-from a terminal.
+Only one stdin flag can be used in an invocation:
 
 | Flag | Input |
 |------|-------|
-| `--password-stdin` | Master password used to unlock a software keystore |
-| `--tx-stdin` | Signed transaction JSON consumed by `tx broadcast` |
-| `--message-stdin` | Message consumed by `message sign` |
+| `--password-stdin` | Software-wallet master password. |
+| `--tx-stdin` | Transaction JSON for `tx broadcast`. |
+| `--message-stdin` | Message for `message sign`. |
 
-Only one `*-stdin` flag can consume stdin in a single invocation. Transaction JSON and hex are not
-secrets; they remain command/file inputs so stdin stays available for a password.
+`import mnemonic`, `import private-key`, and `change-password` require hidden input from a real
+terminal.
 
-The following high-value setup operations are interactive-only and require hidden input from a real
-TTY:
+## Protect local data
 
-- `import mnemonic`
-- `import private-key`
-- `change-password`
+- Wallet files, backups, and generated keypairs contain secrets. Store them securely and do not
+  share them.
+- Service secrets in `config.yaml` are masked when displayed. Keep the configuration file private.
+- Signed transaction files do not contain private keys, but their contents should still be reviewed
+  before sharing or broadcasting.
+- Use `--print-secret` only in a controlled offline terminal.
 
-They do not accept `--mnemonic-stdin`, `--private-key-stdin`, or `--password-stdin`. Without a TTY,
-they fail with `tty_required`.
-
-## Local files and terminal output
-
-- Software keystores and backups contain secrets. Backups and generated keypairs are written with
-  mode `0600`, and an existing output file is never overwritten.
-- The contact book is plaintext but restricted to mode `0600`; a symlink or group/world-readable
-  file is rejected.
-- `config.yaml` is rejected with `insecure_config` when it contains a non-empty
-  `gasfreeApiSecret` or `tronlinkSecretKey` and is a symlink or group/world-readable. Those two
-  secret fields are masked when displayed; the corresponding API key, secret id, and channel are
-  not masked.
-- In text mode, control bytes are removed and invisible Unicode formatting characters from chain or
-  provider data are rendered visibly, for example `<U+202E>`. JSON is not rewritten; machine
-  consumers must neutralize untrusted text before displaying it.
-- Files produced by `tx sign --out` contain transaction artifacts rather than private keys and use
-  mode `0644`.
-
-## Failure behavior
-
-- Watch-only accounts return `watch_only_no_signer` before a signing operation starts.
-- Invalid global values return `invalid_value` rather than falling back to defaults.
-- Ledger setting and version problems use `ledger_setting_required` and `ledger_unsupported`.
-- A transaction whose representations disagree returns `tx_integrity`.
-- An unauthorized, duplicate, or late multi-signature attempt returns `not_authorized`,
-  `already_signed`, or `tx_expired`.
-- User or device refusal returns `signing_rejected`.
-
-JSON mode returns these codes in a single `wallet-cli.result.v1` envelope and uses exit code 1 for
-execution failures and exit code 2 for invalid usage.
-
-For complete field-level command references, see
+For all options and response fields, see the upstream references for
 [`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md),
 [`tx approvals`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/approvals.md),
-and [`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md).
+and
+[`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md).

--- a/docs/clients/wallet-cli/typescript-cli-signing.md
+++ b/docs/clients/wallet-cli/typescript-cli-signing.md
@@ -4,57 +4,99 @@ The TypeScript CLI supports software keystores, Ledger accounts, and watch-only 
 private keys stay encrypted locally, Ledger private keys never leave the device, and watch-only
 accounts can query state but cannot sign.
 
-## Sign an existing transaction
+## Transaction signing modes
 
-`tx sign` signs a TRON transaction constructed outside wallet-cli without broadcasting it:
+`tx sign` accepts two transaction representations with different purposes:
+
+| Input | Purpose | Network behavior |
+|-------|---------|------------------|
+| `--transaction <json>` | Compatibility path for signing one unsigned JSON transaction | Offline for a software account; `--network` is optional |
+| `--hex <hex>` / `--file <path>` | Append one signature to an unsigned or partially signed artifact | Checks permission membership and approval weight online by default; `--offline` disables those checks |
+
+The command never broadcasts. Use `tx broadcast` after signing.
+
+### Sign unsigned JSON
+
+The JSON compatibility path signs a transaction built elsewhere and returns the same `data.signed`
+shape as a transaction-building command in `--sign-only` mode:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
-  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json
+  wallet-cli tx sign \
+    --transaction "$TX_JSON" \
+    --password-stdin \
+    --output json
 ```
 
-For a software account, signing is offline and `--network` is optional. The command is a pure
-signer: it does not decide whether the signer owns the transaction, whether a contract call is
-desirable, or how much value should move. The caller remains responsible for policy checks.
+This is a direct single-signature path. The caller remains responsible for deciding who should sign
+and whether the operation is desirable; wallet-cli verifies payload integrity before using the key.
 
-### Transaction integrity
+### Append a signature to a hex artifact
+
+For multi-signature transactions, use `--hex` or `--file`. Existing signatures are preserved and
+exactly one signature from the selected account is appended:
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx sign \
+    --file transaction.hex \
+    --account cosigner \
+    --network tron:nile \
+    --out transaction.signed.hex \
+    --password-stdin
+```
+
+Before decrypting a software key, the default online mode asks the node for the transaction's
+permission group and refuses when:
+
+- the selected account is not a key in the group (`not_authorized`);
+- that account has already signed (`already_signed`);
+- the transaction has expired (`tx_expired`).
+
+The result reports the signer's weight, accumulated weight, missing weight, whether the threshold
+has been reached, and the new transaction hex. `tx sign` has no `--permission-id`: the permission id
+is already part of the transaction body and cannot change between signers.
+
+Use `--offline` with `--hex` or `--file` on an air-gapped signing machine. It skips permission and
+approval lookups but retains local decoding and integrity checks. The receipt then reports a
+signature count rather than authoritative weight; inspect the artifact later with `tx approvals`.
+`--out` writes the resulting artifact atomically with mode `0644`. A signed transaction is not a
+secret, although its contents should still be reviewed before distribution.
+
+For the end-to-end permission, co-signing, and broadcast sequence, see
+[TypeScript CLI multi-signature](typescript-cli-multisig.md).
+
+## Transaction integrity
 
 A TRON transaction represents its content in three related fields:
 
 | Field | Purpose |
 |-------|---------|
-| `raw_data` | Human- and application-readable transaction content. |
-| `raw_data_hex` | Bytes executed by the node. |
-| `txID` | Hash covered by the signature. |
+| `raw_data` | Human- and application-readable transaction content |
+| `raw_data_hex` | Bytes executed by the node |
+| `txID` | SHA-256 hash covered by every signature |
 
-Before signing, wallet-cli requires `txID` to equal the SHA-256 hash of `raw_data_hex`. It also
-decodes the outer transaction envelope and requires the contract types declared in `raw_data` to
-match those encoded in `raw_data_hex`. For contract types that can be re-encoded, it additionally
-requires the field-level contents of `raw_data` to produce the same bytes. A mismatch returns
-`tx_integrity` and no signature is produced.
+Before signing, wallet-cli requires `txID` to equal the SHA-256 hash of `raw_data_hex`. It decodes
+the outer transaction envelope and requires the contract types declared in `raw_data` to match the
+encoded bytes. For contract types that can be re-encoded, it also requires the field-level content
+of `raw_data` to produce the same bytes. A mismatch returns `tx_integrity` and no signature is
+produced.
 
-`MarketSellAssetContract`, `MarketCancelOrderContract`, and `ShieldedTransferContract` cannot be
-re-encoded by the underlying library. Their transaction hash and contract type are still checked,
-but their `raw_data` field values cannot be verified against `raw_data_hex`; callers must treat those
-displayed field values as unverified.
+Six contract types cannot be re-encoded by TronWeb for the field-level integrity comparison:
 
-### Multi-signature transactions
+- `VoteAssetContract`
+- `UnfreezeAssetContract`
+- `CustomContract`
+- `ShieldedTransferContract`
+- `MarketSellAssetContract`
+- `MarketCancelOrderContract`
 
-When the input already contains a `signature` array, `tx sign` appends the new signature rather than
-replacing existing signatures. The same partially signed transaction can therefore move from one
-authorized signer to the next until its permission threshold is met.
-
-Extract the signed payload and broadcast it later:
-
-```bash
-printf '%s\n' "$WALLET_PASSWORD" |
-  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json |
-  jq -c '.data.signed' > signed.json
-
-wallet-cli tx broadcast --network tron:nile --tx-stdin < signed.json
-```
-
-Text output prints the complete signature rather than an abbreviated transaction identifier.
+Hex/file input containing any of these contracts is rejected with `invalid_transaction`, because
+the artifact cannot be displayed and verified completely. `VoteAssetContract` and `CustomContract`
+are rejected as unsupported contract type ids; the other four are rejected because they cannot be
+decoded losslessly. The JSON compatibility path can sign all six after checking the transaction
+hash and contract type, but their displayed `raw_data` field values cannot be independently verified
+against `raw_data_hex`.
 
 ## Sign typed data
 
@@ -83,7 +125,7 @@ domain and message before signing.
 ## Ledger behavior
 
 Both `tx sign` and `typed-data sign` support Ledger accounts. Transaction-integrity checks run
-before software and Ledger signing alike.
+before software and Ledger signing alike. Do not pass `--password-stdin` for a Ledger account.
 
 Typed-data signing uses the TRON application's hash-signing capability. Enable
 **Settings > Sign by Hash > Allowed** on the device. Otherwise the CLI returns
@@ -99,17 +141,21 @@ on the host before approving it on the device.
 
 ## Secret input policy
 
-Secrets are never accepted as command-line arguments or environment configuration.
+Wallet secrets — master passwords, mnemonics, and private keys — are never accepted as command-line
+arguments or environment configuration. Supported stdin channels are:
 
-The supported stdin channels are:
+Signing with a software account requires the master password through `--password-stdin`. Commands
+without an explicit interactive password flow never prompt for a missing password, even when run
+from a terminal.
 
 | Flag | Input |
 |------|-------|
-| `--password-stdin` | Master password used to unlock a software keystore. |
-| `--tx-stdin` | Signed transaction JSON consumed by `tx broadcast`. |
-| `--message-stdin` | Message consumed by `message sign`. |
+| `--password-stdin` | Master password used to unlock a software keystore |
+| `--tx-stdin` | Signed transaction JSON consumed by `tx broadcast` |
+| `--message-stdin` | Message consumed by `message sign` |
 
-Only one `*-stdin` flag can consume stdin in a single invocation.
+Only one `*-stdin` flag can consume stdin in a single invocation. Transaction JSON and hex are not
+secrets; they remain command/file inputs so stdin stays available for a password.
 
 The following high-value setup operations are interactive-only and require hidden input from a real
 TTY:
@@ -121,17 +167,36 @@ TTY:
 They do not accept `--mnemonic-stdin`, `--private-key-stdin`, or `--password-stdin`. Without a TTY,
 they fail with `tty_required`.
 
+## Local files and terminal output
+
+- Software keystores and backups contain secrets. Backups and generated keypairs are written with
+  mode `0600`, and an existing output file is never overwritten.
+- The contact book is plaintext but restricted to mode `0600`; a symlink or group/world-readable
+  file is rejected.
+- `config.yaml` is rejected with `insecure_config` when it contains a non-empty
+  `gasfreeApiSecret` or `tronlinkSecretKey` and is a symlink or group/world-readable. Those two
+  secret fields are masked when displayed; the corresponding API key, secret id, and channel are
+  not masked.
+- In text mode, control bytes are removed and invisible Unicode formatting characters from chain or
+  provider data are rendered visibly, for example `<U+202E>`. JSON is not rewritten; machine
+  consumers must neutralize untrusted text before displaying it.
+- Files produced by `tx sign --out` contain transaction artifacts rather than private keys and use
+  mode `0644`.
+
 ## Failure behavior
 
-- Watch-only accounts return `watch_only_no_signer` before a signing or write operation starts.
+- Watch-only accounts return `watch_only_no_signer` before a signing operation starts.
 - Invalid global values return `invalid_value` rather than falling back to defaults.
 - Ledger setting and version problems use `ledger_setting_required` and `ledger_unsupported`.
 - A transaction whose representations disagree returns `tx_integrity`.
+- An unauthorized, duplicate, or late multi-signature attempt returns `not_authorized`,
+  `already_signed`, or `tx_expired`.
 - User or device refusal returns `signing_rejected`.
 
 JSON mode returns these codes in a single `wallet-cli.result.v1` envelope and uses exit code 1 for
 execution failures and exit code 2 for invalid usage.
 
 For complete field-level command references, see
-[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md) and
-[`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md).
+[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md),
+[`tx approvals`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/approvals.md),
+and [`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md).

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -1,12 +1,11 @@
 # TypeScript / npm CLI
 
-Starting with release 4.9.7 of the `wallet-cli` repository, the repository also ships an agent-first
-TypeScript CLI. This CLI is published as the npm package `@tron-walletcli/wallet-cli`. Starting with
-4.10.1, its npm package version is aligned with the wallet-cli release line; `wallet-cli --version`
-reports that package version. It remains a separate implementation from the Java JAR: the Java CLI
-uses commands such as `send-coin`, while the TypeScript CLI uses grouped commands such as `tx send`.
+Starting with release 4.9.7, the `wallet-cli` repository also ships a TypeScript CLI. It is
+published as `@tron-walletcli/wallet-cli` on npm. Starting with 4.10.1, the npm package version is
+aligned with the wallet-cli release line.
 
-The TypeScript CLI currently supports TRON mainnet, Nile, and Shasta. EVM chains are not supported.
+The TypeScript CLI is separate from the Java JAR. It uses grouped commands such as `tx send` and
+supports TRON mainnet, Nile, and Shasta. EVM chains are not supported.
 
 ## Install
 
@@ -20,70 +19,43 @@ wallet-cli --help
 
 ## Quick start
 
-Create a local HD wallet, select it, and use Nile for test transactions:
+Create a wallet, select it, and use Nile for testing:
 
 ```bash
 wallet-cli create --label main
 wallet-cli list
 wallet-cli use main
-wallet-cli current
 wallet-cli config defaultNetwork tron:nile
 wallet-cli account balance
 ```
 
-You can override the network for one command without changing the default:
+Override the network for one command with `--network`:
 
 ```bash
 wallet-cli account balance --network tron:nile
 ```
 
-## Global options
-
-Common global options include:
+## Common options
 
 | Option | Description |
 |--------|-------------|
 | <code>--output text&#124;json</code>, <code>-o</code> | Select text or JSON output. |
-| `--network` | Network id, such as `tron:mainnet`, `tron:nile`, or `tron:shasta`. |
-| `--account` | Account id, label, or address; defaults to the active account set by `use`. |
-| `--timeout` | Per RPC/device-call timeout in milliseconds. |
-| `--verbose`, `-v` | Show extra diagnostics. |
-| `--wait` | After broadcast, poll until the transaction is confirmed or failed. |
-| `--wait-timeout` | Polling cap for `--wait`, in milliseconds; defaults to `config.waitTimeoutMs` (built-in: 60000). |
-| `--password-stdin` | Read the master password from stdin. |
+| `--network` | Select `tron:mainnet`, `tron:nile`, or `tron:shasta`. |
+| `--account` | Select an account by id, label, or address. |
+| `--wait` | After submission, poll until a final state or the wait timeout. |
+| `--password-stdin` | Read a software-wallet password from stdin. |
 
-Command-scoped stdin flags are `--tx-stdin` and `--message-stdin`. Together with the global
-`--password-stdin`, only one `*-stdin` flag can consume stdin in a single invocation.
-
-Use `wallet-cli config` to persist defaults. For example:
+Use `wallet-cli config` to view or persist defaults:
 
 ```bash
+wallet-cli config
 wallet-cli config waitTimeoutMs 90000
 ```
 
-GasFree and TronLink multi-signature collaboration use optional external-service configuration:
-
-| Key | Purpose |
-|-----|---------|
-| `gasfreeApiKey` / `gasfreeApiSecret` | Authenticate `gasfree info`, `transfer`, and `trace`. |
-| `tronlinkSecretId` / `tronlinkSecretKey` / `tronlinkChannel` | Authenticate `tx multisig`. |
-
-These credentials are environment-specific: use credentials that match the mainnet or testnet
-selected by `--network`. The secret fields `gasfreeApiSecret` and `tronlinkSecretKey` are masked
-when displayed. When either secret field is present, `config.yaml` must not be a symbolic link and
-must have no group or world permissions on POSIX; otherwise the CLI returns `insecure_config`. An
-unreadable or invalid configuration returns `invalid_config`.
-
 ## Wallets and accounts
 
-The TypeScript CLI stores its data under `~/.wallet-cli` by default. Set `WALLET_CLI_HOME` to isolate
-test or automation data.
-
-```bash
-WALLET_CLI_HOME=/tmp/wallet-cli-demo wallet-cli list --output json
-```
-
-Useful wallet commands:
+Wallet data is stored under `~/.wallet-cli` by default. Set `WALLET_CLI_HOME` to use another
+location, for example when testing or running automation.
 
 ```bash
 wallet-cli create --label main
@@ -94,39 +66,32 @@ wallet-cli import ledger --app tron --index 0 --label cold
 wallet-cli list
 wallet-cli use main
 wallet-cli current
-wallet-cli current --qr
 wallet-cli rename main --label primary
 wallet-cli backup primary --out ~/primary-backup.json
 wallet-cli change-password
 ```
 
-`import mnemonic`, `import private-key`, and `change-password` are interactive-only. They require a
-real terminal and read secrets through hidden prompts; there is no non-interactive stdin alternative.
+Mnemonic and private-key imports and password changes require a real terminal and use hidden
+prompts. They do not accept secrets as command-line arguments.
 
-For a software account, an invocation that must decrypt a key and has no explicit interactive
-password flow—such as `derive` or a signing mode of `tx sign` or `tx send`—must receive the master
-password through `--password-stdin`; it never prompts when the flag is missing. `backup` is
-different: it can read the password from a hidden TTY prompt, while `--password-stdin` remains
-available for non-interactive backups. When signing with a Ledger account, do not pipe a password or
-pass `--password-stdin`. The `derive` example below shows the complete non-interactive form. To keep
-later examples concise, they may omit the password pipe and `--password-stdin`.
+Software accounts must provide the master password through `--password-stdin` for commands that
+sign or decrypt a key without an interactive password flow. Backups can use either a hidden terminal
+prompt or `--password-stdin`. Ledger accounts do not use `--password-stdin`.
 
-For HD sub-account derivation, pass the HD seed id shown by `wallet-cli list`.
+To keep later command listings concise, signing examples may omit the password pipe and
+`--password-stdin`. Software accounts must add them; Ledger accounts must not.
+
+For HD sub-account derivation, pass the seed id shown by `wallet-cli list`:
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
   wallet-cli derive --seed-id wlt_ab12cd34 --label operations --password-stdin
 ```
 
-Deleting a root HD wallet cascades to accounts derived from that root and cleans orphan labels. In a
-non-interactive shell, pass `--yes`; otherwise the command asks for confirmation.
+Delete an account with `wallet-cli delete`. Deleting a root HD wallet also removes accounts derived
+from it. Use `--yes` only when you intentionally want to skip confirmation.
 
-```bash
-wallet-cli delete old --yes
-```
-
-The CLI can also activate a new on-chain address and set the selected account's on-chain name or
-account id:
+The CLI can activate a new address and set the selected account's on-chain name or id:
 
 ```bash
 wallet-cli account activate --address TNewAddress... --network tron:nile --dry-run
@@ -134,68 +99,45 @@ wallet-cli account set --name "Acme Treasury" --network tron:nile --dry-run
 wallet-cli account set --id acme-treasury-01 --network tron:nile --dry-run
 ```
 
-`account activate` makes the selected account pay the account-creation fee. An account's on-chain
-name and id can each be set only once and cannot be changed afterward; `account set` has no
-confirmation prompt. This is different from `rename`, which only changes a reusable local wallet
-label. Signing or broadcasting `account activate` or `account set --id` requires a software account,
-because the Ledger TRON app cannot decode `AccountCreateContract` or `SetAccountIdContract`.
-Ledger accounts can sign `account set --name`, and can use `--dry-run` or `--build-only` for all
-three operations because those modes do not sign. Review these operations with `--dry-run` before
-submitting them.
+`account activate` charges the selected account the current account-creation fee. An on-chain
+account name and id can each be set only once. This differs from `rename`, which changes only a
+reusable local label. `account activate` and `account set --id` cannot be signed by a Ledger account.
+Review these operations with `--dry-run` before submitting them.
 
 ## Transactions
 
-Amounts passed with `--amount` are human amounts. Use `--raw-amount` for SUN or token base units.
+Amounts passed with `--amount` are human-readable amounts. Use `--raw-amount` for SUN or token base
+units.
 
 ```bash
 wallet-cli tx send --to T... --amount 1 --dry-run
-wallet-cli tx send --to T... --amount 1 --wait
-wallet-cli tx send --to T... --token USDT --amount 5
-wallet-cli tx send --to T... --contract TR7... --amount 5
-wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000
+wallet-cli tx send --to T... --token USDT --amount 5 --dry-run
+wallet-cli tx send --to T... --contract TR7... --amount 5 --dry-run
+wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000 --dry-run
 ```
 
-Transaction-building commands support four execution modes:
+Transaction-building commands support four modes:
 
 | Mode | Behavior |
 |------|----------|
 | default | Build, sign, and broadcast. |
 | `--dry-run` | Build and estimate without signing or broadcasting. |
-| `--sign-only` | Build and sign, then output signed transaction hex without broadcasting. |
-| `--build-only` | Build and output unsigned transaction hex without unlocking a wallet. |
+| `--sign-only` | Build and sign without broadcasting. |
+| `--build-only` | Build without signing or unlocking a wallet. |
 
-These commands also accept `--permission-id <n>` to select the transaction's owner, witness, or
-active permission. `--sign-only` and `--build-only` accept `--expiration <ms>` up to 24 hours, which
-gives co-signers time to approve the same artifact. The default node expiration is approximately
-60 seconds and is usually too short for a multi-party workflow.
+Add `--wait` to poll for a confirmed or failed result. If the wait timeout is reached first, the
+command returns `submitted`; without `--wait`, it returns immediately after submission.
 
-The default mode returns after the transaction is submitted. Add `--wait` to poll the FullNode's
-unconfirmed view until the transaction is confirmed or failed. If the polling cap is reached, the
-CLI returns the submitted receipt rather than pretending that the broadcast failed.
-
-Broadcast signed hex later, preferably from a file:
+Broadcast a previously signed artifact from a file:
 
 ```bash
 wallet-cli tx broadcast --file signed.hex --network tron:nile
-```
-
-`tx broadcast` also accepts inline `--hex`, or the compatibility JSON inputs `--transaction` and
-`--tx-stdin`. It rejects an expired transaction locally (`tx_expired`), then queries the node's
-read-only permission endpoints and rejects insufficient signature weight (`not_authorized`) before
-calling the broadcast endpoint. Use `tx broadcast --dry-run` to perform those checks and calculate
-the dynamic multi-signature fee without broadcasting. The fee is a chain parameter read at runtime
-and applies when the transaction contains more than one signature; it is currently 1 TRX on
-mainnet.
-
-`tx status` returns a four-state model: `confirmed`, `failed`, `pending`, or `not_found`.
-
-```bash
 wallet-cli tx status --txid <TXID>
 wallet-cli tx info --txid <TXID> --output json
 ```
 
-The CLI supports two signing inputs. `--transaction` retains the direct single-signature JSON path;
-`--hex` and `--file` append a signature to a multi-signature artifact:
+`tx sign` accepts JSON for the direct signing path and hex or file input for multi-signature
+artifacts:
 
 ```bash
 wallet-cli tx sign --transaction "$TX_JSON"
@@ -203,63 +145,53 @@ wallet-cli tx approvals --file transaction.hex --network tron:nile
 wallet-cli tx sign --file transaction.hex --out signed.hex --network tron:nile
 ```
 
-Before decrypting a software key, the default online mode checks the selected account's permission
-membership and rejects duplicate approvals. After appending the signature, it reports the updated
-accumulated and missing weight. Add `--offline` to skip the node-backed permission check while
-preserving local payload-integrity checks. See
-[Multi-signature](typescript-cli-multisig.md) for the complete workflow and
-[Signing and security](typescript-cli-signing.md) for integrity and device behavior.
+Hex and file signing checks the selected permission and existing approvals online. Use `--offline`
+on an air-gapped signer, then check the result later with `tx approvals`. See
+[Multi-signature](typescript-cli-multisig.md) and
+[Signing and security](typescript-cli-signing.md).
 
 ## Permissions and multi-signature
 
-TRON permissions contain weighted signer keys and a threshold. Permission id `0` is the owner,
-`1` is the optional witness permission, and ids `2`–`9` are scoped active permissions.
+TRON permissions use weighted signer keys and a threshold. Inspect the current permissions and
+dry-run any replacement before signing it:
 
 ```bash
 wallet-cli permission show --account main --network tron:nile
-wallet-cli permission show --account main --network tron:nile --output json
 wallet-cli permission update --file permissions.json --network tron:nile --dry-run
 wallet-cli tx approvals --file transaction.hex --network tron:nile
 ```
 
-`permission update` replaces the entire permission structure and burns a chain-set fee that the CLI
-reads at runtime; it is currently 100 TRX on mainnet. A bad owner group can permanently lock the
-account; the CLI emits `owner_lockout` or `owner_lockout_partial` warnings but does not block a
-deliberately multi-party configuration. The optional `tx multisig` command uses the TronLink service
-to hold an artifact, collect signatures, notify co-signers, and broadcast after the threshold is
-reached. The service is not required: artifacts can instead be passed directly between signers. See
-[Multi-signature](typescript-cli-multisig.md).
+`permission update` replaces the complete permission structure and charges the chain's current
+permission-update fee. An incorrect owner permission can permanently lock the account.
+
+The optional `tx multisig` command uses the TronLink service to coordinate signatures. The service
+is not required; signers can exchange transaction files directly. See
+[Multi-signature](typescript-cli-multisig.md) for both workflows.
 
 ## Queries
 
-Wallet-bound queries use the active account by default, or the account selected with `--account`.
+Wallet-bound queries use the active account unless `--account` selects another one.
 
 ```bash
 wallet-cli account info --output json
 wallet-cli account history --limit 10
 wallet-cli account portfolio
 wallet-cli networks
-wallet-cli block
 wallet-cli block 12345
 wallet-cli chain params
 wallet-cli chain prices
 wallet-cli chain node
 wallet-cli stake info
-wallet-cli stake delegated --direction out
 wallet-cli vote status
 wallet-cli reward balance
 ```
 
-Block responses are parsed losslessly. Protobuf `int64`/`uint64` values outside JavaScript's safe
-integer range are returned as exact decimal strings rather than rounded numbers.
-
-For field-level command semantics and additional examples, see the
-[upstream TypeScript command reference](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands).
+For all supported options and response fields, see the
+[upstream command reference](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands).
 
 ## Tokens and contracts
 
-The token address book includes common mainnet tokens such as USDT and USDC, and can be extended with
-custom TRC-20 contracts.
+The token address book includes common mainnet tokens and supports custom TRC-20 contracts.
 
 ```bash
 wallet-cli token add --contract TR7...
@@ -269,7 +201,7 @@ wallet-cli token info --contract TR7...
 wallet-cli token remove --contract TR7...
 ```
 
-Contract calls use JSON-encoded parameter descriptors:
+Contract calls use JSON-encoded parameters:
 
 ```bash
 wallet-cli contract info --contract TR7...
@@ -293,23 +225,13 @@ wallet-cli contract deploy \
   --dry-run
 ```
 
-In JSON output, a successful TypeScript CLI contract deployment includes the deployed
-`contractAddress` in the deploy receipt data.
-
-`contract info` returns a not-found error when the address has no deployed contract instead of
-returning an empty contract.
-
-Contract deployment requires a software account. The Ledger TRON app cannot sign
-`CreateSmartContract`, so Ledger-backed accounts cannot use `wallet-cli contract deploy`.
-
-`contract send --dry-run` compares the supplied `--fee-limit` with the estimated energy cost and
-warns when the limit is likely to make the transaction fail.
+Signing or broadcasting a contract deployment requires a software account. Ledger accounts can use
+`--dry-run` or `--build-only` because those modes do not sign.
 
 ## GasFree transfers
 
-The TypeScript CLI can transfer provider-supported tokens without holding TRX. The GasFree service
-deducts its fee in the transferred token and returns a provider `traceId` while the transfer is
-being relayed:
+GasFree can transfer supported tokens without requiring the account to hold TRX. The service
+charges its fee in the transferred token.
 
 ```bash
 wallet-cli gasfree info --network tron:nile
@@ -317,14 +239,13 @@ wallet-cli gasfree transfer --to T... --amount 25 --token USDT --network tron:ni
 wallet-cli gasfree trace <TRACE_ID> --network tron:nile
 ```
 
-GasFree supports mainnet and Nile, not Shasta, and requires `gasfreeApiKey` and
-`gasfreeApiSecret`. A submitted GasFree transfer is not yet an on-chain transaction: follow its
-provider states with `--wait` or `gasfree trace`, not `tx status`. See
+GasFree supports mainnet and Nile and requires service credentials. A submitted request returns a
+GasFree trace id; follow it with `--wait` or `gasfree trace`. See
 [TypeScript CLI GasFree](typescript-cli-gasfree.md).
 
 ## Stake 2.0
 
-Stake amounts are specified in SUN. The TypeScript CLI exposes Stake 2.0 commands:
+Stake amounts are specified in SUN.
 
 ```bash
 wallet-cli stake freeze --amount-sun 1000000 --resource energy --dry-run
@@ -337,20 +258,10 @@ wallet-cli stake info
 wallet-cli stake delegated --direction out
 ```
 
-`stake cancel-unfreeze` requires a software account; the Ledger TRON app cannot sign
-`CancelAllUnfreezeV2Contract`.
-
-`stake withdraw` checks the withdrawable amount before building a transaction and returns
-`nothing_to_withdraw` when no expired unfreeze is available.
-
-`stake freeze` and `stake unfreeze` also preflight the available balance or currently staked amount,
-including in `--dry-run`, and return `insufficient_balance` or `insufficient_stake` for a request the
-node would inevitably reject.
+Signing or broadcasting `stake cancel-unfreeze` requires a software account. Ledger accounts can
+use `--dry-run` or `--build-only` because those modes do not sign.
 
 ## Voting and rewards
-
-The TypeScript CLI can inspect super representatives, replace the account's vote allocation, query
-claimable rewards, and withdraw those rewards:
 
 ```bash
 wallet-cli vote list
@@ -360,15 +271,11 @@ wallet-cli reward balance
 wallet-cli reward withdraw
 ```
 
-`vote cast` replaces the complete existing vote allocation; omitted SRs receive zero votes. Both
-`vote cast` and `reward withdraw` create transactions and require a signing account.
-`reward withdraw` returns `no_reward` when the claimable balance is empty and
-`withdraw_too_frequent` when the 24-hour withdrawal interval has not elapsed.
+`vote cast` replaces the complete vote allocation, so omitted representatives receive no votes.
+Signing or broadcasting `vote cast` or `reward withdraw` requires a software or Ledger account;
+`--dry-run` and `--build-only` do not sign.
 
 ## Local utilities
-
-The 4.11.0 command surface includes recipient contacts, offline key generation, address and byte
-encoding conversion, and a receive QR:
 
 ```bash
 wallet-cli contact add alice T... --note "Alice mainnet"
@@ -381,18 +288,14 @@ wallet-cli encoding convert T...
 wallet-cli current --qr
 ```
 
-The contact book is a local plaintext file restricted to mode `0600`; contact names can be used by
-`tx send --to` and `gasfree transfer --to`. `address generate` creates a keypair locally but does
-not add it to the wallet. By default it writes the private key to an exclusively created `0600`
-file; `--print-secret` deliberately prints it to stdout and should be used only in a controlled
-offline terminal. `encoding convert` accepts public/address/byte encodings but rejects 32-byte
-private-key-shaped input so secrets are not placed in shell history.
+Contacts are stored locally and can be used as recipients for `tx send` and `gasfree transfer`.
+`address generate` creates a keypair without importing it into the wallet. Protect the generated
+private-key file and use `--print-secret` only in a controlled offline terminal.
 
 ## Signing
 
-In addition to `message sign`, the CLI provides `tx sign` and EIP-712/TIP-712 `typed-data sign`.
-Software and Ledger accounts are supported; watch-only accounts fail before a write or signing
-operation begins.
+The CLI supports message, transaction, and EIP-712/TIP-712 typed-data signing. Software and Ledger
+accounts can sign; watch-only accounts cannot.
 
 ```bash
 wallet-cli message sign --message 'hello'
@@ -400,47 +303,25 @@ wallet-cli tx sign --transaction "$TX_JSON"
 wallet-cli typed-data sign --typed-data "$TYPED_DATA_JSON"
 ```
 
-See [Signing and security](typescript-cli-signing.md) for transaction-integrity checks,
-multi-signature behavior, Ledger settings, and secret-input rules.
+See [Signing and security](typescript-cli-signing.md) for password input, Ledger settings, offline
+signing, and transaction review.
 
 ## Automation
 
-JSON mode emits one `wallet-cli.result.v1` envelope to stdout and uses deterministic exit codes:
+JSON output uses a single `wallet-cli.result.v1` envelope. Exit codes are stable:
 
 | Code | Meaning |
 |------|---------|
-| `0` | Success. |
-| `1` | Execution, authentication, device, or chain error. |
-| `2` | Invalid command usage or arguments. |
+| `0` | The command completed successfully. |
+| `1` | A runtime or execution failure occurred. |
+| `2` | A usage, input, or configuration error occurred. |
 
-For broadcast commands, exit status describes whether the CLI completed the request, not the
-on-chain result. With `--wait`, a mined transaction that reverted is still a successful command:
-the envelope has `success: true` and exits `0`, while `data.stage` is `"failed"`. Scripts must
-branch on `data.stage` after waiting and must not treat `stage: "submitted"` as confirmation.
+For commands using `--wait`, inspect `data.stage`: `"confirmed"` and `"failed"` are final outcomes,
+while `"submitted"` is not.
 
-`meta.warnings` can contain either a string or an object with stable `code` and human-readable
-`message` fields. Permission lockout and post-confirmation warnings use the object form. Normalize
-both shapes before displaying warnings and branch only on object `code`, never message text.
-
-On-chain amounts and integers that may exceed JavaScript's safe range are serialized as decimal
-strings. Chain- or provider-controlled text is left unchanged in JSON, so consumers must neutralize
-control and invisible formatting characters before displaying it. Text mode performs that
-neutralization automatically.
-
-Agents and scripts can discover the complete command catalog and JSON Schemas without parsing
-human-readable help:
+Scripts can discover commands and JSON Schemas without parsing human-readable help:
 
 ```bash
 wallet-cli --json-schema
 wallet-cli tx send --json-schema
 ```
-
-Canonical command ids do not carry a `tron.` prefix: for example, the id is `tx.send`, not
-`tron.tx.send`. The network family remains available separately in `chain.family`.
-
-Invalid global values such as `--timeout 0` or an unsupported `--output` value fail with
-`invalid_value` instead of silently falling back to a default.
-
-A node broadcast is considered accepted only when the node explicitly returns `result: true`.
-Rejections are surfaced as `transaction_rejected` rather than as a successful receipt containing a
-transaction id that never reached the node.

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -1,10 +1,10 @@
 # TypeScript / npm CLI
 
 Starting with release 4.9.7 of the `wallet-cli` repository, the repository also ships an agent-first
-TypeScript CLI. This CLI is published as the npm package `@tron-walletcli/wallet-cli` and uses an
-independent npm version number; `wallet-cli --version` reports the npm package version. It is
-separate from the Java JAR described in the rest of this section: the Java CLI uses commands such
-as `send-coin`, while the TypeScript CLI uses grouped commands such as `tx send`.
+TypeScript CLI. This CLI is published as the npm package `@tron-walletcli/wallet-cli`. Starting with
+4.10.1, its npm package version is aligned with the wallet-cli release line; `wallet-cli --version`
+reports that package version. It remains a separate implementation from the Java JAR: the Java CLI
+uses commands such as `send-coin`, while the TypeScript CLI uses grouped commands such as `tx send`.
 
 The TypeScript CLI currently supports TRON mainnet, Nile, and Shasta. EVM chains are not supported.
 
@@ -61,6 +61,19 @@ Use `wallet-cli config` to persist defaults. For example:
 wallet-cli config waitTimeoutMs 90000
 ```
 
+GasFree and TronLink multi-signature collaboration use optional external-service configuration:
+
+| Key | Purpose |
+|-----|---------|
+| `gasfreeApiKey` / `gasfreeApiSecret` | Authenticate `gasfree info`, `transfer`, and `trace`. |
+| `tronlinkSecretId` / `tronlinkSecretKey` / `tronlinkChannel` | Authenticate `tx multisig`. |
+
+These credentials are environment-specific: use credentials that match the mainnet or testnet
+selected by `--network`. The secret fields `gasfreeApiSecret` and `tronlinkSecretKey` are masked
+when displayed. When either secret field is present, `config.yaml` must not be a symbolic link and
+must have no group or world permissions on POSIX; otherwise the CLI returns `insecure_config`. An
+unreadable or invalid configuration returns `invalid_config`.
+
 ## Wallets and accounts
 
 The TypeScript CLI stores its data under `~/.wallet-cli` by default. Set `WALLET_CLI_HOME` to isolate
@@ -81,6 +94,7 @@ wallet-cli import ledger --app tron --index 0 --label cold
 wallet-cli list
 wallet-cli use main
 wallet-cli current
+wallet-cli current --qr
 wallet-cli rename main --label primary
 wallet-cli backup primary --out ~/primary-backup.json
 wallet-cli change-password
@@ -89,8 +103,11 @@ wallet-cli change-password
 `import mnemonic`, `import private-key`, and `change-password` are interactive-only. They require a
 real terminal and read secrets through hidden prompts; there is no non-interactive stdin alternative.
 
-For non-interactive use with commands such as `derive`, `backup`, and `tx sign`, provide the master
-password through `--password-stdin`. When signing with a Ledger account, do not pipe a password or
+For a software account, an invocation that must decrypt a key and has no explicit interactive
+password flow—such as `derive` or a signing mode of `tx sign` or `tx send`—must receive the master
+password through `--password-stdin`; it never prompts when the flag is missing. `backup` is
+different: it can read the password from a hidden TTY prompt, while `--password-stdin` remains
+available for non-interactive backups. When signing with a Ledger account, do not pipe a password or
 pass `--password-stdin`. The `derive` example below shows the complete non-interactive form. To keep
 later examples concise, they may omit the password pipe and `--password-stdin`.
 
@@ -108,6 +125,24 @@ non-interactive shell, pass `--yes`; otherwise the command asks for confirmation
 wallet-cli delete old --yes
 ```
 
+The CLI can also activate a new on-chain address and set the selected account's on-chain name or
+account id:
+
+```bash
+wallet-cli account activate --address TNewAddress... --network tron:nile --dry-run
+wallet-cli account set --name "Acme Treasury" --network tron:nile --dry-run
+wallet-cli account set --id acme-treasury-01 --network tron:nile --dry-run
+```
+
+`account activate` makes the selected account pay the account-creation fee. An account's on-chain
+name and id can each be set only once and cannot be changed afterward; `account set` has no
+confirmation prompt. This is different from `rename`, which only changes a reusable local wallet
+label. Signing or broadcasting `account activate` or `account set --id` requires a software account,
+because the Ledger TRON app cannot decode `AccountCreateContract` or `SetAccountIdContract`.
+Ledger accounts can sign `account set --name`, and can use `--dry-run` or `--build-only` for all
+three operations because those modes do not sign. Review these operations with `--dry-run` before
+submitting them.
+
 ## Transactions
 
 Amounts passed with `--amount` are human amounts. Use `--raw-amount` for SUN or token base units.
@@ -120,23 +155,37 @@ wallet-cli tx send --to T... --contract TR7... --amount 5
 wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000
 ```
 
-Transaction-building commands support three execution modes:
+Transaction-building commands support four execution modes:
 
 | Mode | Behavior |
 |------|----------|
 | default | Build, sign, and broadcast. |
 | `--dry-run` | Build and estimate without signing or broadcasting. |
-| `--sign-only` | Sign and output the transaction without broadcasting. |
+| `--sign-only` | Build and sign, then output signed transaction hex without broadcasting. |
+| `--build-only` | Build and output unsigned transaction hex without unlocking a wallet. |
+
+These commands also accept `--permission-id <n>` to select the transaction's owner, witness, or
+active permission. `--sign-only` and `--build-only` accept `--expiration <ms>` up to 24 hours, which
+gives co-signers time to approve the same artifact. The default node expiration is approximately
+60 seconds and is usually too short for a multi-party workflow.
 
 The default mode returns after the transaction is submitted. Add `--wait` to poll the FullNode's
 unconfirmed view until the transaction is confirmed or failed. If the polling cap is reached, the
 CLI returns the submitted receipt rather than pretending that the broadcast failed.
 
-Broadcast a signed transaction later with:
+Broadcast signed hex later, preferably from a file:
 
 ```bash
-wallet-cli tx broadcast --tx-stdin < signed.json
+wallet-cli tx broadcast --file signed.hex --network tron:nile
 ```
+
+`tx broadcast` also accepts inline `--hex`, or the compatibility JSON inputs `--transaction` and
+`--tx-stdin`. It rejects an expired transaction locally (`tx_expired`), then queries the node's
+read-only permission endpoints and rejects insufficient signature weight (`not_authorized`) before
+calling the broadcast endpoint. Use `tx broadcast --dry-run` to perform those checks and calculate
+the dynamic multi-signature fee without broadcasting. The fee is a chain parameter read at runtime
+and applies when the transaction contains more than one signature; it is currently 1 TRX on
+mainnet.
 
 `tx status` returns a four-state model: `confirmed`, `failed`, `pending`, or `not_found`.
 
@@ -145,16 +194,41 @@ wallet-cli tx status --txid <TXID>
 wallet-cli tx info --txid <TXID> --output json
 ```
 
-The CLI also provides a pure, offline-capable signer for transactions constructed elsewhere:
+The CLI supports two signing inputs. `--transaction` retains the direct single-signature JSON path;
+`--hex` and `--file` append a signature to a multi-signature artifact:
 
 ```bash
 wallet-cli tx sign --transaction "$TX_JSON"
+wallet-cli tx approvals --file transaction.hex --network tron:nile
+wallet-cli tx sign --file transaction.hex --out signed.hex --network tron:nile
 ```
 
-It always verifies that `txID` is the hash of `raw_data_hex` and that the declared contract types
-match the encoded transaction. For contract types that can be re-encoded, it also verifies the
-field-level contents of `raw_data`. It appends to an existing signature array for multi-signature
-workflows. See [Signing and security](typescript-cli-signing.md#sign-an-existing-transaction).
+Before decrypting a software key, the default online mode checks the selected account's permission
+membership and rejects duplicate approvals. After appending the signature, it reports the updated
+accumulated and missing weight. Add `--offline` to skip the node-backed permission check while
+preserving local payload-integrity checks. See
+[Multi-signature](typescript-cli-multisig.md) for the complete workflow and
+[Signing and security](typescript-cli-signing.md) for integrity and device behavior.
+
+## Permissions and multi-signature
+
+TRON permissions contain weighted signer keys and a threshold. Permission id `0` is the owner,
+`1` is the optional witness permission, and ids `2`–`9` are scoped active permissions.
+
+```bash
+wallet-cli permission show --account main --network tron:nile
+wallet-cli permission show --account main --network tron:nile --output json
+wallet-cli permission update --file permissions.json --network tron:nile --dry-run
+wallet-cli tx approvals --file transaction.hex --network tron:nile
+```
+
+`permission update` replaces the entire permission structure and burns a chain-set fee that the CLI
+reads at runtime; it is currently 100 TRX on mainnet. A bad owner group can permanently lock the
+account; the CLI emits `owner_lockout` or `owner_lockout_partial` warnings but does not block a
+deliberately multi-party configuration. The optional `tx multisig` command uses the TronLink service
+to hold an artifact, collect signatures, notify co-signers, and broadcast after the threshold is
+reached. The service is not required: artifacts can instead be passed directly between signers. See
+[Multi-signature](typescript-cli-multisig.md).
 
 ## Queries
 
@@ -175,6 +249,9 @@ wallet-cli stake delegated --direction out
 wallet-cli vote status
 wallet-cli reward balance
 ```
+
+Block responses are parsed losslessly. Protobuf `int64`/`uint64` values outside JavaScript's safe
+integer range are returned as exact decimal strings rather than rounded numbers.
 
 For field-level command semantics and additional examples, see the
 [upstream TypeScript command reference](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands).
@@ -225,6 +302,26 @@ returning an empty contract.
 Contract deployment requires a software account. The Ledger TRON app cannot sign
 `CreateSmartContract`, so Ledger-backed accounts cannot use `wallet-cli contract deploy`.
 
+`contract send --dry-run` compares the supplied `--fee-limit` with the estimated energy cost and
+warns when the limit is likely to make the transaction fail.
+
+## GasFree transfers
+
+The TypeScript CLI can transfer provider-supported tokens without holding TRX. The GasFree service
+deducts its fee in the transferred token and returns a provider `traceId` while the transfer is
+being relayed:
+
+```bash
+wallet-cli gasfree info --network tron:nile
+wallet-cli gasfree transfer --to T... --amount 25 --token USDT --network tron:nile --dry-run
+wallet-cli gasfree trace <TRACE_ID> --network tron:nile
+```
+
+GasFree supports mainnet and Nile, not Shasta, and requires `gasfreeApiKey` and
+`gasfreeApiSecret`. A submitted GasFree transfer is not yet an on-chain transaction: follow its
+provider states with `--wait` or `gasfree trace`, not `tx status`. See
+[TypeScript CLI GasFree](typescript-cli-gasfree.md).
+
 ## Stake 2.0
 
 Stake amounts are specified in SUN. The TypeScript CLI exposes Stake 2.0 commands:
@@ -246,6 +343,10 @@ wallet-cli stake delegated --direction out
 `stake withdraw` checks the withdrawable amount before building a transaction and returns
 `nothing_to_withdraw` when no expired unfreeze is available.
 
+`stake freeze` and `stake unfreeze` also preflight the available balance or currently staked amount,
+including in `--dry-run`, and return `insufficient_balance` or `insufficient_stake` for a request the
+node would inevitably reject.
+
 ## Voting and rewards
 
 The TypeScript CLI can inspect super representatives, replace the account's vote allocation, query
@@ -263,6 +364,29 @@ wallet-cli reward withdraw
 `vote cast` and `reward withdraw` create transactions and require a signing account.
 `reward withdraw` returns `no_reward` when the claimable balance is empty and
 `withdraw_too_frequent` when the 24-hour withdrawal interval has not elapsed.
+
+## Local utilities
+
+The 4.11.0 command surface includes recipient contacts, offline key generation, address and byte
+encoding conversion, and a receive QR:
+
+```bash
+wallet-cli contact add alice T... --note "Alice mainnet"
+wallet-cli contact list
+wallet-cli tx send --to alice --amount 1 --network tron:nile --dry-run
+wallet-cli contact remove alice
+
+wallet-cli address generate --out ./generated-keypair.json
+wallet-cli encoding convert T...
+wallet-cli current --qr
+```
+
+The contact book is a local plaintext file restricted to mode `0600`; contact names can be used by
+`tx send --to` and `gasfree transfer --to`. `address generate` creates a keypair locally but does
+not add it to the wallet. By default it writes the private key to an exclusively created `0600`
+file; `--print-secret` deliberately prints it to stdout and should be used only in a controlled
+offline terminal. `encoding convert` accepts public/address/byte encodings but rejects 32-byte
+private-key-shaped input so secrets are not placed in shell history.
 
 ## Signing
 
@@ -289,6 +413,20 @@ JSON mode emits one `wallet-cli.result.v1` envelope to stdout and uses determini
 | `1` | Execution, authentication, device, or chain error. |
 | `2` | Invalid command usage or arguments. |
 
+For broadcast commands, exit status describes whether the CLI completed the request, not the
+on-chain result. With `--wait`, a mined transaction that reverted is still a successful command:
+the envelope has `success: true` and exits `0`, while `data.stage` is `"failed"`. Scripts must
+branch on `data.stage` after waiting and must not treat `stage: "submitted"` as confirmation.
+
+`meta.warnings` can contain either a string or an object with stable `code` and human-readable
+`message` fields. Permission lockout and post-confirmation warnings use the object form. Normalize
+both shapes before displaying warnings and branch only on object `code`, never message text.
+
+On-chain amounts and integers that may exceed JavaScript's safe range are serialized as decimal
+strings. Chain- or provider-controlled text is left unchanged in JSON, so consumers must neutralize
+control and invisible formatting characters before displaying it. Text mode performs that
+neutralization automatically.
+
 Agents and scripts can discover the complete command catalog and JSON Schemas without parsing
 human-readable help:
 
@@ -302,3 +440,7 @@ Canonical command ids do not carry a `tron.` prefix: for example, the id is `tx.
 
 Invalid global values such as `--timeout 0` or an unsupported `--output` value fail with
 `invalid_value` instead of silently falling back to a default.
+
+A node broadcast is considered accepted only when the node explicitly returns `result: true`.
+Rejections are surfaced as `transaction_rejected` rather than as a successful receipt containing a
+transaction id that never reached the node.

--- a/docs/clients/wallet-cli/wallet-management.md
+++ b/docs/clients/wallet-cli/wallet-management.md
@@ -174,8 +174,7 @@ Deletes the encrypted keystore file(s) for the wallet from local storage. This i
     java -jar java/build/libs/wallet-cli.jar clear-wallet-keystore --force
     ```
 
-    - `--force` is syntactically optional, but required to execute the destructive action in
-      Standard CLI mode — without it the command fails with a usage error. Requires auth.
+    - Pass `--force` to confirm the destructive action. Requires auth.
 
 === "REPL"
 
@@ -222,20 +221,10 @@ ViewTransactionHistory
 
 ## Aliases (Standard CLI only)
 
-The Standard CLI supports **aliases** — friendly names for accounts and tokens — so you can write
-`--to my-friend` instead of a raw Base58 address. Aliases are scoped per network and come from two
-layers: a set of **built-in** aliases (read-only) and your **user** aliases.
-
-Alias resolution applies to **address** fields, not to numeric IDs:
-
-- **Account aliases** (`--type ACCOUNT`) resolve on address fields such as `--to`, `--from`,
-  `--owner`, `--receiver`, and `--address`.
-- **Token aliases** (`--type TOKEN`) resolve on contract-address fields — the contract `--contract`
-  option and the `--address` of `get-contract` / `get-contract-info`.
-
-They do **not** apply to TRC-10 asset IDs (`--asset`) or to `--token-id`, which are read verbatim as
-numeric IDs. When an alias is resolved, the resolution is reported under `meta.resolved` in JSON
-mode.
+The Standard CLI supports network-specific aliases for account and token addresses, so you can use
+`--to my-friend` instead of a Base58 address. Built-in aliases are read-only; user aliases can be
+added and removed. Account aliases apply to account-address options, while token aliases apply to
+contract-address options. Aliases do not apply to numeric TRC-10 asset IDs or `--token-id`.
 
 ```bash
 # Add an account alias

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -290,6 +290,8 @@ nav:
                 - Queries: clients/wallet-cli/query.md
             - TypeScript / npm CLI:
                 - Overview: clients/wallet-cli/typescript-cli.md
+                - Multi-signature: clients/wallet-cli/typescript-cli-multisig.md
+                - GasFree: clients/wallet-cli/typescript-cli-gasfree.md
                 - Signing & Security: clients/wallet-cli/typescript-cli-signing.md
     - Releases:
         - Deployment Manual for the New Version: releases/upgrade-instruction.md


### PR DESCRIPTION
## Summary

- document TypeScript CLI features added after wallet-cli v4.10.0, including permissions, multi-signature, GasFree, account lifecycle, contacts, and local utilities
- clarify signing, password input, transaction modes, and automation behavior
- simplify the TypeScript and Java CLI documentation for a public-facing audience

## Validation

- verified with mkdocs build --strict
- checked with git diff --check