### PR TITLE
align docs with java-tron v4.8.2.1

### DIFF
--- a/docs/developers/network.md
+++ b/docs/developers/network.md
@@ -32,9 +32,6 @@ As the most fundamental module of TRON, the P2P network directly determines the 
 
 The underlying implementations of **Node Discovery** and **Node Connection** have been extracted from the java-tron repository into a standalone external dependency, [`io.github.tronprotocol:libp2p`](https://github.com/tronprotocol/libp2p). This library is responsible for low-level node discovery (based on the Kademlia algorithm) and connection transport, and it adds capabilities such as DNS-based node discovery. The TRON protocol layer above it — including the P2P_HELLO handshake, P2P_PING/P2P_PONG keep-alive, peer business-state management, message dispatch, synchronization, and broadcast — is still implemented in java-tron's `core/net`, which integrates with libp2p through `TronNetService`. For the low-level discovery and connection implementation details, please refer to the libp2p repository; they are no longer covered in this document.
 
-Starting with libp2p v2.2.9, log output from abnormal peer handshake messages is
-limited to reduce excessive log growth and memory usage.
-
 **Block Synchronization** and **Block and Transaction Broadcast** are still implemented in java-tron's `core/net`, and are introduced separately below.
 
 ## Peer Connection Management

--- a/docs/developers/network.md
+++ b/docs/developers/network.md
@@ -32,6 +32,9 @@ As the most fundamental module of TRON, the P2P network directly determines the 
 
 The underlying implementations of **Node Discovery** and **Node Connection** have been extracted from the java-tron repository into a standalone external dependency, [`io.github.tronprotocol:libp2p`](https://github.com/tronprotocol/libp2p). This library is responsible for low-level node discovery (based on the Kademlia algorithm) and connection transport, and it adds capabilities such as DNS-based node discovery. The TRON protocol layer above it — including the P2P_HELLO handshake, P2P_PING/P2P_PONG keep-alive, peer business-state management, message dispatch, synchronization, and broadcast — is still implemented in java-tron's `core/net`, which integrates with libp2p through `TronNetService`. For the low-level discovery and connection implementation details, please refer to the libp2p repository; they are no longer covered in this document.
 
+Starting with libp2p v2.2.9, log output from abnormal peer handshake messages is
+limited to reduce excessive log growth and memory usage.
+
 **Block Synchronization** and **Block and Transaction Broadcast** are still implemented in java-tron's `core/net`, and are introduced separately below.
 
 ## Peer Connection Management

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -148,6 +148,11 @@ Request and message size limits are configured independently:
 - `node.jsonrpc.maxMessageSize` controls JSON-RPC request bodies.
 - `node.jsonrpc.maxBatchSize`, `maxResponseSize`, and filter limits constrain JSON-RPC workloads.
 
+`node.rpc.maxConcurrentCallsPerConnection` limits the number of concurrent gRPC
+calls on one connection. Its default value is `100`, and setting it to `0` also
+uses `100`. If a client needs more than 100 concurrent calls on one connection,
+configure a larger positive value.
+
 Use `node.disabledApi` to disable selected HTTP, gRPC, or PBFT methods. It does not disable JSON-RPC methods; disable a JSON-RPC service with its `node.jsonrpc.*Enable` switch.
 
 Do not expose administrative or transaction-building APIs directly to an untrusted network. Restrict listening access with host or network controls, and place public services behind an appropriately configured gateway when necessary. See the [HTTP API](../api/http/index.md) and [JSON-RPC API](../api/json-rpc/index.md) guides for protocol-specific behavior.


### PR DESCRIPTION
## Summary

- document the libp2p v2.2.9 logging improvement for abnormal peer handshake messages
- document the gRPC per-connection concurrent call limit and its default behavior

## Testing

- mkdocs build --strict